### PR TITLE
Fix unexpected secret recreation

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -22,6 +22,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Setup GO
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.go_version }}
+
       - name: Check Code Style
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -25,8 +25,8 @@ jobs:
       - name: Check Code Style
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.49.0 ## https://github.com/golangci/golangci-lint/releases
-          args: --timeout 3m0s
+          version: v1.52.2 ## https://github.com/golangci/golangci-lint/releases
+          args: --timeout 5m0s
 
   unit-test:
     runs-on: ubuntu-latest

--- a/api/v1alpha1/database_types.go
+++ b/api/v1alpha1/database_types.go
@@ -156,7 +156,6 @@ func (db *Database) InstanceAccessSecretName() string {
 
 // ConvertTo converts this v1alpha1 to v1beta1. (upgrade)
 func (db *Database) ConvertTo(dstRaw conversion.Hub) error {
-
 	dst := dstRaw.(*v1beta1.Database)
 	dst.ObjectMeta = db.ObjectMeta
 

--- a/api/v1beta1/webhook_suite_test.go
+++ b/api/v1beta1/webhook_suite_test.go
@@ -42,11 +42,13 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
-var k8sClient client.Client
-var testEnv *envtest.Environment
-var ctx context.Context
-var cancel context.CancelFunc
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -124,7 +126,6 @@ var _ = BeforeSuite(func() {
 		conn.Close()
 		return nil
 	}).Should(Succeed())
-
 })
 
 var _ = AfterSuite(func() {

--- a/controllers/backup/cronjob_test.go
+++ b/controllers/backup/cronjob_test.go
@@ -135,6 +135,7 @@ func TestGCSBackupCronGenericWithOwnerReference(t *testing.T) {
 	assert.Equal(t, funcCronObject.OwnerReferences[0].Name, ownership[0].Name, "Name in the OwnerReference is wrong")
 	assert.Equal(t, funcCronObject.OwnerReferences[0].UID, ownership[0].UID, "UID in the OwnerReference is wrong")
 }
+
 func TestGetResourceRequirements(t *testing.T) {
 	os.Setenv("CONFIG_PATH", "./test/backup_config.yaml")
 	conf := config.LoadConfig()

--- a/controllers/database_controller.go
+++ b/controllers/database_controller.go
@@ -595,7 +595,7 @@ func (r *DatabaseReconciler) createTemplatedSecrets(ctx context.Context, dbcr *k
 	// Adding values
 	newSecretData := fillTemplatedSecretData(dbcr, databaseSecret.Data, dbSecrets, ownership)
 	newSecretData = removeObsoleteSecret(dbcr, databaseSecret.Data, dbSecrets, ownership)
-	
+
 	for key, value := range newSecretData {
 		databaseSecret.Data[key] = value
 	}

--- a/controllers/database_controller.go
+++ b/controllers/database_controller.go
@@ -593,8 +593,8 @@ func (r *DatabaseReconciler) createTemplatedSecrets(ctx context.Context, dbcr *k
 		return err
 	}
 	// Adding values
-	newSecretData := fillTemplatedSecretData(dbcr, databaseSecret.Data, dbSecrets, ownership)
-	newSecretData = removeObsoleteSecret(dbcr, databaseSecret.Data, dbSecrets, ownership)
+	newSecretData := appendTemplatedSecretData(dbcr, databaseSecret.Data, dbSecrets, ownership)
+	newSecretData = removeObsoleteSecret(dbcr, newSecretData, dbSecrets, ownership)
 
 	for key, value := range newSecretData {
 		databaseSecret.Data[key] = value

--- a/controllers/database_controller.go
+++ b/controllers/database_controller.go
@@ -594,7 +594,7 @@ func (r *DatabaseReconciler) createTemplatedSecrets(ctx context.Context, dbcr *k
 	}
 	// Adding values
 	newSecretData := fillTemplatedSecretData(dbcr, databaseSecret.Data, dbSecrets, ownership)
-	newSecretData = removeObsoleteSecret(dbcr, newSecretData, dbSecrets, ownership)
+	newSecretData = removeObsoleteSecret(dbcr, databaseSecret.Data, dbSecrets, ownership)
 	
 	for key, value := range newSecretData {
 		databaseSecret.Data[key] = value

--- a/controllers/database_controller.go
+++ b/controllers/database_controller.go
@@ -593,13 +593,14 @@ func (r *DatabaseReconciler) createTemplatedSecrets(ctx context.Context, dbcr *k
 		return err
 	}
 	// Adding values
-	newSecret := fillTemplatedSecretData(dbcr, databaseSecret.Data, dbSecrets, ownership)
-	if err = r.Update(ctx, newSecret, &client.UpdateOptions{}); err != nil {
-		return err
+	newSecretData := fillTemplatedSecretData(dbcr, databaseSecret.Data, dbSecrets, ownership)
+	newSecretData = removeObsoleteSecret(dbcr, newSecretData, dbSecrets, ownership)
+	
+	for key, value := range newSecretData {
+		databaseSecret.Data[key] = value
 	}
 
-	newSecret = removeObsoleteSecret(dbcr, databaseSecret.Data, dbSecrets, ownership)
-	if err = r.Update(ctx, newSecret, &client.UpdateOptions{}); err != nil {
+	if err = r.Update(ctx, databaseSecret, &client.UpdateOptions{}); err != nil {
 		return err
 	}
 

--- a/controllers/database_helper.go
+++ b/controllers/database_helper.go
@@ -300,7 +300,7 @@ func generateTemplatedSecrets(dbcr *kciv1beta1.Database, databaseCred database.C
 	return secrets, nil
 }
 
-func fillTemplatedSecretData(dbcr *kciv1beta1.Database, secretData map[string][]byte, newSecretFields map[string][]byte, ownership []metav1.OwnerReference) map[string][]byte {
+func appendTemplatedSecretData(dbcr *kciv1beta1.Database, secretData map[string][]byte, newSecretFields map[string][]byte, ownership []metav1.OwnerReference) map[string][]byte {
 	blockedTempatedKeys := getBlockedTempatedKeys()
 	for key, value := range newSecretFields {
 		if slices.Contains(blockedTempatedKeys, key) {

--- a/controllers/database_helper_test.go
+++ b/controllers/database_helper_test.go
@@ -135,8 +135,8 @@ func TestPsqlDefaultTemplatedSecretGeneratationWithProxy(t *testing.T) {
 	postgresDbCr.Status.ProxyStatus.ServiceName = c.DatabaseHost
 
 	protocol := "postgresql"
-	expectedData := map[string]string{
-		"CONNECTION_STRING": byte[](fmt.Sprintf("%s://%s:%s@%s:%d/%s", protocol, c.UserName, c.Password, c.DatabaseHost, c.DatabasePort, c.DatabaseName)),
+	expectedData := map[string][]byte{
+		"CONNECTION_STRING": []byte(fmt.Sprintf("%s://%s:%s@%s:%d/%s", protocol, c.UserName, c.Password, c.DatabaseHost, c.DatabasePort, c.DatabaseName)),
 	}
 
 	connString, err := generateTemplatedSecrets(postgresDbCr, testDbcred)
@@ -160,8 +160,8 @@ func TestPsqlDefaultTemplatedSecretGeneratationWithoutProxy(t *testing.T) {
 	}
 
 	protocol := "postgresql"
-	expectedData := map[string]string{
-		"CONNECTION_STRING": byte[](fmt.Sprintf("%s://%s:%s@%s:%d/%s", protocol, c.UserName, c.Password, c.DatabaseHost, c.DatabasePort, c.DatabaseName)),
+	expectedData := map[string][]byte{
+		"CONNECTION_STRING": []byte(fmt.Sprintf("%s://%s:%s@%s:%d/%s", protocol, c.UserName, c.Password, c.DatabaseHost, c.DatabasePort, c.DatabaseName)),
 	}
 
 	connString, err := generateTemplatedSecrets(postgresDbCr, testDbcred)
@@ -182,8 +182,8 @@ func TestMysqlDefaultTemlatedSecretGeneratationWithoutProxy(t *testing.T) {
 		DatabaseName: testDbcred.Name,
 	}
 	protocol := "mysql"
-	expectedData := map[string]string{
-		"CONNECTION_STRING": byte[](fmt.Sprintf("%s://%s:%s@%s:%d/%s", protocol, c.UserName, c.Password, c.DatabaseHost, c.DatabasePort, c.DatabaseName)),
+	expectedData := map[string][]byte{
+		"CONNECTION_STRING": []byte(fmt.Sprintf("%s://%s:%s@%s:%d/%s", protocol, c.UserName, c.Password, c.DatabaseHost, c.DatabasePort, c.DatabaseName)),
 	}
 
 	connString, err := generateTemplatedSecrets(mysqlDbCr, testDbcred)
@@ -213,9 +213,9 @@ func TestPsqlCustomSecretGeneratation(t *testing.T) {
 		DatabaseName: testDbcred.Name,
 	}
 	protocol := "postgresql"
-	expectedData := map[string]string{
-		"CHECK_1": byte[](fmt.Sprintf("%s%s://%s:%s@%s:%d/%s%s", prefix, protocol, c.UserName, c.Password, c.DatabaseHost, c.DatabasePort, c.DatabaseName, postfix)),
-		"CHECK_2": byte[](fmt.Sprintf("%s://%s:%s@%s:%d/%s", protocol, c.UserName, c.Password, c.DatabaseHost, c.DatabasePort, c.DatabaseName)),
+	expectedData := map[string][]byte{
+		"CHECK_1": []byte(fmt.Sprintf("%s%s://%s:%s@%s:%d/%s%s", prefix, protocol, c.UserName, c.Password, c.DatabaseHost, c.DatabasePort, c.DatabaseName, postfix)),
+		"CHECK_2": []byte(fmt.Sprintf("%s://%s:%s@%s:%d/%s", protocol, c.UserName, c.Password, c.DatabaseHost, c.DatabasePort, c.DatabaseName)),
 	}
 
 	templatedSecrets, err := generateTemplatedSecrets(postgresDbCr, testDbcred)

--- a/controllers/database_helper_test.go
+++ b/controllers/database_helper_test.go
@@ -26,8 +26,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var testDbcred = database.Credentials{Name: "testdb", Username: "testuser", Password: "password"}
-var ownership = []metav1.OwnerReference{}
+var (
+	testDbcred = database.Credentials{Name: "testdb", Username: "testuser", Password: "password"}
+	ownership  = []metav1.OwnerReference{}
+)
 
 func TestDeterminPostgresType(t *testing.T) {
 	postgresDbCr := newPostgresTestDbCr(newPostgresTestDbInstanceCr())

--- a/controllers/database_helper_test.go
+++ b/controllers/database_helper_test.go
@@ -216,12 +216,12 @@ func TestPsqlCustomSecretGeneratation(t *testing.T) {
 		"CHECK_2": fmt.Sprintf("%s://%s:%s@%s:%d/%s", protocol, c.UserName, c.Password, c.DatabaseHost, c.DatabasePort, c.DatabaseName),
 	}
 
-	connString, err := generateTemplatedSecrets(postgresDbCr, testDbcred)
+	templatedSecrets, err := generateTemplatedSecrets(postgresDbCr, testDbcred)
 	if err != nil {
 		t.Logf("unexpected error: %s", err)
 		t.Fail()
 	}
-	assert.Equal(t, connString, expectedData, "generated connections string is wrong")
+	assert.Equal(t, templatedSecrets, expectedData, "generated connections string is wrong")
 }
 
 func TestWrongTemplatedSecretGeneratation(t *testing.T) {

--- a/controllers/database_helper_test.go
+++ b/controllers/database_helper_test.go
@@ -264,7 +264,7 @@ func TestBlockedTempatedKeysGeneratation(t *testing.T) {
 		Data: map[string][]byte{},
 	}
 
-	newSecret := fillTemplatedSecretData(postgresDbCr, dummySecret.Data, sercretData, ownership)
+	newSecret := appendTemplatedSecretData(postgresDbCr, dummySecret.Data, sercretData, ownership)
 	assert.Equal(t, newSecret, expectedData, "generated connections string is wrong")
 }
 
@@ -294,7 +294,7 @@ func TestObsoleteFieldsRemoving(t *testing.T) {
 		},
 	}
 
-	newSecret := fillTemplatedSecretData(postgresDbCr, dummySecret.Data, sercretData, ownership)
+	newSecret := appendTemplatedSecretData(postgresDbCr, dummySecret.Data, sercretData, ownership)
 	newSecret = removeObsoleteSecret(postgresDbCr, dummySecret.Data, sercretData, ownership)
 
 	assert.Equal(t, newSecret, expectedData, "generated connections string is wrong")

--- a/controllers/database_helper_test.go
+++ b/controllers/database_helper_test.go
@@ -136,7 +136,7 @@ func TestPsqlDefaultTemplatedSecretGeneratationWithProxy(t *testing.T) {
 
 	protocol := "postgresql"
 	expectedData := map[string]string{
-		"CONNECTION_STRING": fmt.Sprintf("%s://%s:%s@%s:%d/%s", protocol, c.UserName, c.Password, c.DatabaseHost, c.DatabasePort, c.DatabaseName),
+		"CONNECTION_STRING": byte[](fmt.Sprintf("%s://%s:%s@%s:%d/%s", protocol, c.UserName, c.Password, c.DatabaseHost, c.DatabasePort, c.DatabaseName)),
 	}
 
 	connString, err := generateTemplatedSecrets(postgresDbCr, testDbcred)
@@ -161,7 +161,7 @@ func TestPsqlDefaultTemplatedSecretGeneratationWithoutProxy(t *testing.T) {
 
 	protocol := "postgresql"
 	expectedData := map[string]string{
-		"CONNECTION_STRING": fmt.Sprintf("%s://%s:%s@%s:%d/%s", protocol, c.UserName, c.Password, c.DatabaseHost, c.DatabasePort, c.DatabaseName),
+		"CONNECTION_STRING": byte[](fmt.Sprintf("%s://%s:%s@%s:%d/%s", protocol, c.UserName, c.Password, c.DatabaseHost, c.DatabasePort, c.DatabaseName)),
 	}
 
 	connString, err := generateTemplatedSecrets(postgresDbCr, testDbcred)
@@ -183,7 +183,7 @@ func TestMysqlDefaultTemlatedSecretGeneratationWithoutProxy(t *testing.T) {
 	}
 	protocol := "mysql"
 	expectedData := map[string]string{
-		"CONNECTION_STRING": fmt.Sprintf("%s://%s:%s@%s:%d/%s", protocol, c.UserName, c.Password, c.DatabaseHost, c.DatabasePort, c.DatabaseName),
+		"CONNECTION_STRING": byte[](fmt.Sprintf("%s://%s:%s@%s:%d/%s", protocol, c.UserName, c.Password, c.DatabaseHost, c.DatabasePort, c.DatabaseName)),
 	}
 
 	connString, err := generateTemplatedSecrets(mysqlDbCr, testDbcred)
@@ -214,8 +214,8 @@ func TestPsqlCustomSecretGeneratation(t *testing.T) {
 	}
 	protocol := "postgresql"
 	expectedData := map[string]string{
-		"CHECK_1": fmt.Sprintf("%s%s://%s:%s@%s:%d/%s%s", prefix, protocol, c.UserName, c.Password, c.DatabaseHost, c.DatabasePort, c.DatabaseName, postfix),
-		"CHECK_2": fmt.Sprintf("%s://%s:%s@%s:%d/%s", protocol, c.UserName, c.Password, c.DatabaseHost, c.DatabasePort, c.DatabaseName),
+		"CHECK_1": byte[](fmt.Sprintf("%s%s://%s:%s@%s:%d/%s%s", prefix, protocol, c.UserName, c.Password, c.DatabaseHost, c.DatabasePort, c.DatabaseName, postfix)),
+		"CHECK_2": byte[](fmt.Sprintf("%s://%s:%s@%s:%d/%s", protocol, c.UserName, c.Password, c.DatabaseHost, c.DatabasePort, c.DatabaseName)),
 	}
 
 	templatedSecrets, err := generateTemplatedSecrets(postgresDbCr, testDbcred)

--- a/controllers/database_helper_test.go
+++ b/controllers/database_helper_test.go
@@ -192,25 +192,6 @@ func TestMysqlDefaultTemlatedSecretGeneratationWithoutProxy(t *testing.T) {
 	assert.Equal(t, connString, expectedData, "generated connections string is wrong")
 }
 
-func TestAddingTemplatedSecretsToSecret(t *testing.T) {
-	instance := newPostgresTestDbInstanceCr()
-	postgresDbCr := newPostgresTestDbCr(instance)
-	secretData := map[string][]byte{
-		"POSTGRES_DB":       []byte("postgres"),
-		"POSTGRES_USER":     []byte("root"),
-		"POSTGRES_PASSWORD": []byte("qwertyu9"),
-	}
-
-	connectionString := "it's a dummy connection string"
-
-	secret := addTemplatedSecretToSecret(postgresDbCr, secretData, "TMPL", connectionString, ownership)
-	secretData["CONNECTION_STRING"] = []byte(connectionString)
-	if val, ok := secret.Data["TMPL"]; ok {
-		assert.Equal(t, string(val), connectionString, "connections string in a secret contains unexpected values")
-		return
-	}
-}
-
 func TestPsqlCustomSecretGeneratation(t *testing.T) {
 	instance := newPostgresTestDbInstanceCr()
 	postgresDbCr := newPostgresTestDbCr(instance)
@@ -282,7 +263,7 @@ func TestBlockedTempatedKeysGeneratation(t *testing.T) {
 	}
 
 	newSecret := fillTemplatedSecretData(postgresDbCr, dummySecret.Data, sercretData, ownership)
-	assert.Equal(t, newSecret.Data, expectedData, "generated connections string is wrong")
+	assert.Equal(t, newSecret, expectedData, "generated connections string is wrong")
 }
 
 func TestObsoleteFieldsRemoving(t *testing.T) {
@@ -314,5 +295,5 @@ func TestObsoleteFieldsRemoving(t *testing.T) {
 	newSecret := fillTemplatedSecretData(postgresDbCr, dummySecret.Data, sercretData, ownership)
 	newSecret = removeObsoleteSecret(postgresDbCr, dummySecret.Data, sercretData, ownership)
 
-	assert.Equal(t, newSecret.Data, expectedData, "generated connections string is wrong")
+	assert.Equal(t, newSecret, expectedData, "generated connections string is wrong")
 }

--- a/pkg/utils/database/mysql.go
+++ b/pkg/utils/database/mysql.go
@@ -25,8 +25,8 @@ import (
 	"github.com/GoogleCloudPlatform/cloudsql-proxy/proxy/dialers/mysql"
 
 	// do not delete
-	_ "github.com/go-sql-driver/mysql"
 	"github.com/db-operator/db-operator/pkg/utils/kci"
+	_ "github.com/go-sql-driver/mysql"
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/utils/database/postgres_test.go
+++ b/pkg/utils/database/postgres_test.go
@@ -84,7 +84,7 @@ func TestPostgresCreateDatabaseTemplate(t *testing.T) {
 
 	testquery = "SELECT role_id, role_name FROM test;"
 	assert.NoError(t, p.executeExec("postgres", testquery, admin))
-	
+
 	testquery = "SELECT role_id, role_name, role_unknown FROM test;"
 	assert.Error(t, p.executeExec("postgres", testquery, admin))
 }

--- a/pkg/utils/kci/decorator_test.go
+++ b/pkg/utils/kci/decorator_test.go
@@ -46,9 +46,9 @@ func TestConfigMapBuilderWithOwnerReference(t *testing.T) {
 	ownership := []metav1.OwnerReference{}
 	ownership = append(ownership, metav1.OwnerReference{
 		APIVersion: "api-version",
-		Kind: "kind",
-		Name: "name",
-		UID: "uid",
+		Kind:       "kind",
+		Name:       "name",
+		UID:        "uid",
 	})
 	om := metav1.ObjectMeta{Namespace: "TestNS"}
 	s := v1alpha1.DatabaseSpec{SecretName: "TestSec"}
@@ -92,9 +92,9 @@ func TestSecretBuilderWithOwnerReference(t *testing.T) {
 
 	ownership = append(ownership, metav1.OwnerReference{
 		APIVersion: "api-version",
-		Kind: "kind",
-		Name: "name",
-		UID: "uid",
+		Kind:       "kind",
+		Name:       "name",
+		UID:        "uid",
 	})
 
 	owner := v1alpha1.Database{ObjectMeta: o}


### PR DESCRIPTION
Issue: https://github.com/db-operator/db-operator/issues/4

Shortly, when secrets templates are updated, the whole secret is recreated and hence all the data that could have been added to that secret is gone

AC: 
- [x] Only `spec.data` should be updated