### PR TITLE
Add `db-operator` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # Temporary Build Files
 build/_output
 build/_test
+db-operator
 
 # Secret file for local testing
 secrets-local.yaml


### PR DESCRIPTION
I'm running `go build` from time to time and always adding `db-operator` binary to `git`