### PR TITLE
Add support for `nerdctl`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.5-alpine3.18 as builder
+FROM registry.hub.docker.com/library/golang:1.20.5-alpine3.18 as builder
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash build-base
@@ -16,7 +16,7 @@ COPY . .
 ARG GOARCH
 RUN GOOS=linux GOARCH=$GOARCH CGO_ENABLED=0 go build -tags build -o /usr/local/bin/db-operator main.go
 
-FROM alpine:3.18
+FROM registry.hub.docker.com/library/alpine:3.18
 LABEL org.opencontainers.image.authors="Nikolai Rodionov<allanger@zohomail.com>"
 
 ENV USER_UID=1001
@@ -28,4 +28,4 @@ COPY ./build/bin /usr/local/bin
 RUN /usr/local/bin/user_setup
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
-USER ${USER_UID}
+USER $USER_UID


### PR DESCRIPTION
I'm using `nerdctl` instead of `docker` now, so build is a little bit different, also, nerdctl doesn't know about docker default URLs for images, so it should be full paths

Also test dependencies can be run using the `nerdctl compose` command