### PR TITLE
Set dbuser access type on database removing

### DIFF
--- a/controllers/database_controller.go
+++ b/controllers/database_controller.go
@@ -391,6 +391,7 @@ func (r *DatabaseReconciler) deleteDatabase(ctx context.Context, dbcr *kindav1be
 		// failed to determine database type
 		return err
 	}
+	dbuser.AccessType = database.ACCESS_TYPE_MAINUSER
 
 	adminSecretResource, err := r.getAdminSecret(ctx, dbcr)
 	if err != nil {


### PR DESCRIPTION
It's most probably causing the endless test workflow for the v1.13.0 release, example here (https://github.com/db-operator/charts/actions/runs/5831636739)