### PR TITLE
Fix additional users creation, when the operator user is not Super Admin

### DIFF
--- a/internal/controller/database_helper.go
+++ b/internal/controller/database_helper.go
@@ -80,7 +80,7 @@ func determinDatabaseType(dbcr *kindav1beta1.Database, dbCred database.Credentia
 			DropPublicSchema: dbcr.Spec.Postgres.DropPublicSchema,
 			Schemas:          dbcr.Spec.Postgres.Schemas,
 			Template:         dbcr.Spec.Postgres.Template,
-			MainUser:         dbcr.Status.UserName,
+			MainUser:         dbuser,
 		}
 		return db, dbuser, nil
 
@@ -201,7 +201,7 @@ func getSSLMode(dbcr *kindav1beta1.Database) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	
+
 	genericSSL, err := getGenericSSLMode(dbcr)
 	if err != nil {
 		return "", err
@@ -209,30 +209,30 @@ func getSSLMode(dbcr *kindav1beta1.Database) (string, error) {
 
 	if engine == "postgres" {
 		switch genericSSL {
-			case SSL_DISABLED:
-				return "disable", nil
-			case SSL_REQUIRED:
-				return "require", nil
-			case SSL_VERIFY_CA:
-				return "verify-ca", nil
+		case SSL_DISABLED:
+			return "disable", nil
+		case SSL_REQUIRED:
+			return "require", nil
+		case SSL_VERIFY_CA:
+			return "verify-ca", nil
 		}
-	} 
-	
+	}
+
 	if engine == "mysql" {
 		switch genericSSL {
-			case SSL_DISABLED:
-				return "disabled", nil
-			case SSL_REQUIRED:
-				return "required", nil
-			case SSL_VERIFY_CA:
-				return "verify_ca", nil
+		case SSL_DISABLED:
+			return "disabled", nil
+		case SSL_REQUIRED:
+			return "required", nil
+		case SSL_VERIFY_CA:
+			return "verify_ca", nil
 		}
 	}
 
 	return "", fmt.Errorf("unknown database engine: %s", engine)
 }
 
-func getGenericSSLMode(dbcr *kindav1beta1.Database) (string, error){
+func getGenericSSLMode(dbcr *kindav1beta1.Database) (string, error) {
 	instance, err := dbcr.GetInstanceRef()
 	if err != nil {
 		return "", err
@@ -247,4 +247,3 @@ func getGenericSSLMode(dbcr *kindav1beta1.Database) (string, error){
 		}
 	}
 }
-

--- a/pkg/utils/database/handler.go
+++ b/pkg/utils/database/handler.go
@@ -17,7 +17,7 @@
 package database
 
 // CreateDatabase executes queries to create database
-func CreateDatabase(db Database, admin AdminCredentials) error {
+func CreateDatabase(db Database, admin *DatabaseUser) error {
 	err := db.createDatabase(admin)
 	if err != nil {
 		return err
@@ -26,7 +26,7 @@ func CreateDatabase(db Database, admin AdminCredentials) error {
 }
 
 // DeleteDatabase executes queries to delete database and user
-func DeleteDatabase(db Database, admin AdminCredentials) error {
+func DeleteDatabase(db Database, admin *DatabaseUser) error {
 	err := db.deleteDatabase(admin)
 	if err != nil {
 		return err
@@ -36,7 +36,7 @@ func DeleteDatabase(db Database, admin AdminCredentials) error {
 }
 
 // CreateOrUpdateUser executes queries to create or update user
-func CreateOrUpdateUser(db Database, dbuser *DatabaseUser, admin AdminCredentials) error {
+func CreateOrUpdateUser(db Database, dbuser *DatabaseUser, admin *DatabaseUser) error {
 	err := db.createOrUpdateUser(admin, dbuser)
 	if err != nil {
 		return err
@@ -45,7 +45,7 @@ func CreateOrUpdateUser(db Database, dbuser *DatabaseUser, admin AdminCredential
 }
 
 // CreateUser executes queries to a create user
-func CreateUser(db Database, dbuser *DatabaseUser, admin AdminCredentials) error {
+func CreateUser(db Database, dbuser *DatabaseUser, admin *DatabaseUser) error {
 	err := db.createUser(admin, dbuser)
 	if err != nil {
 		return err
@@ -53,7 +53,7 @@ func CreateUser(db Database, dbuser *DatabaseUser, admin AdminCredentials) error
 	return nil
 }
 
-func UpdateUser(db Database, dbuser *DatabaseUser, admin AdminCredentials) error {
+func UpdateUser(db Database, dbuser *DatabaseUser, admin *DatabaseUser) error {
 	err := db.createOrUpdateUser(admin, dbuser)
 	if err != nil {
 		return err
@@ -61,7 +61,7 @@ func UpdateUser(db Database, dbuser *DatabaseUser, admin AdminCredentials) error
 	return nil
 }
 
-func DeleteUser(db Database, dbuser *DatabaseUser, admin AdminCredentials) error {
+func DeleteUser(db Database, dbuser *DatabaseUser, admin *DatabaseUser) error {
 	err := db.deleteUser(admin, dbuser)
 	if err != nil {
 		return err

--- a/pkg/utils/database/mysql_test.go
+++ b/pkg/utils/database/mysql_test.go
@@ -28,8 +28,11 @@ func testMysql() (*Mysql, *DatabaseUser) {
 	return &Mysql{"local", test.GetMysqlHost(), test.GetMysqlPort(), "testdb", false, false}, &DatabaseUser{Username: "testuser", Password: "testpwd", AccessType: ACCESS_TYPE_MAINUSER}
 }
 
-func getMysqlAdmin() AdminCredentials {
-	return AdminCredentials{"root", test.GetMysqlAdminPassword()}
+func getMysqlAdmin() *DatabaseUser {
+	return &DatabaseUser{
+		Username: "root",
+		Password: test.GetMysqlAdminPassword(),
+	}
 }
 
 func TestMysqlCheckStatus(t *testing.T) {

--- a/pkg/utils/database/postgres_test.go
+++ b/pkg/utils/database/postgres_test.go
@@ -44,8 +44,11 @@ func testPostgres() (*Postgres, *DatabaseUser) {
 		}
 }
 
-func getPostgresAdmin() AdminCredentials {
-	return AdminCredentials{"postgres", test.GetPostgresAdminPassword()}
+func getPostgresAdmin() *DatabaseUser {
+	return &DatabaseUser{
+		Username: "postgres",
+		Password: test.GetPostgresAdminPassword(),
+	}
 }
 
 func TestPostgresExecuteQuery(t *testing.T) {

--- a/pkg/utils/database/postgres_test.go
+++ b/pkg/utils/database/postgres_test.go
@@ -24,6 +24,12 @@ import (
 )
 
 func testPostgres() (*Postgres, *DatabaseUser) {
+	dbuser := &DatabaseUser{
+		Username:   "testuser",
+		Password:   "testpassword",
+		AccessType: ACCESS_TYPE_MAINUSER,
+	}
+
 	return &Postgres{
 			Backend:          "local",
 			Host:             test.GetPostgresHost(),
@@ -35,13 +41,9 @@ func testPostgres() (*Postgres, *DatabaseUser) {
 			SkipCAVerify:     false,
 			DropPublicSchema: false,
 			Schemas:          []string{},
-			MainUser:         "testuser",
+			MainUser:         dbuser,
 		},
-		&DatabaseUser{
-			Username:   "testuser",
-			Password:   "testpassword",
-			AccessType: ACCESS_TYPE_MAINUSER,
-		}
+		dbuser
 }
 
 func getPostgresAdmin() *DatabaseUser {

--- a/pkg/utils/database/types.go
+++ b/pkg/utils/database/types.go
@@ -31,8 +31,8 @@ type Credentials struct {
 }
 
 type DatabaseUser struct {
-	Username   string
-	Password   string
+	Username   string `yaml:"user"`
+	Password   string `yaml:"password"`
 	AccessType string
 }
 
@@ -52,13 +52,13 @@ type AdminCredentials struct {
 type Database interface {
 	CheckStatus(user *DatabaseUser) error
 	GetCredentials(user *DatabaseUser) Credentials
-	ParseAdminCredentials(data map[string][]byte) (AdminCredentials, error)
+	ParseAdminCredentials(data map[string][]byte) (*DatabaseUser, error)
 	GetDatabaseAddress() DatabaseAddress
-	createDatabase(admin AdminCredentials) error
-	deleteDatabase(admin AdminCredentials) error
-	createOrUpdateUser(admin AdminCredentials, user *DatabaseUser) error
-	createUser(admin AdminCredentials, user *DatabaseUser) error
-	updateUser(admin AdminCredentials, user *DatabaseUser) error
-	deleteUser(admin AdminCredentials, user *DatabaseUser) error
-	setUserPermission(admin AdminCredentials, user *DatabaseUser) error
+	createDatabase(admin *DatabaseUser) error
+	deleteDatabase(admin *DatabaseUser) error
+	createOrUpdateUser(admin *DatabaseUser, user *DatabaseUser) error
+	createUser(admin *DatabaseUser, user *DatabaseUser) error
+	updateUser(admin *DatabaseUser, user *DatabaseUser) error
+	deleteUser(admin *DatabaseUser, user *DatabaseUser) error
+	setUserPermission(admin *DatabaseUser, user *DatabaseUser) error
 }


### PR DESCRIPTION
When your user is not a `Super Admin`, and apparently it's the case when you're on Azure, the admin user that the operator is using to operator as, operator can't run some queries on the that are required for creating additional users. 
It's solved by running some GRANTS as the main database user (that is created by the operator)

Another change is rather a clean-up, after adding a DatabaseUser struct, the AdminCredentials could have been replaced by it, because it contains required fields (Password and Username). 