### PR TITLE
Fix the test for MySQL handler

### DIFF
--- a/pkg/utils/database/handler_test.go
+++ b/pkg/utils/database/handler_test.go
@@ -52,14 +52,6 @@ func TestCreateMysql(t *testing.T) {
 	admin := getMysqlAdmin()
 	t.Log(m.Database)
 	err := CreateDatabase(m, admin)
-	// TODO(@allanger): This test is actually passing,
-	//   so I guess that the problem was the username, but no database,
-	//   so I need to check it out
-	//
-	// assert.Errorf(t, err, "Should get error %v", err)
-	// m.Database = "testdb"
-	// err = CreateDatabase(m, admin)
-
 	assert.NoErrorf(t, err, "Unexpected error %v", err)
 
 	err = CreateUser(m, dbu, admin)


### PR DESCRIPTION
After splitting database creation into database and user creation, I've found out that the test that was expecting an error was failing. I have checked that databases with 'unallowed' symbols in names can be created. And they actually can, so the test was not assuming a correct output. It was working before, most likely, because db user couldn't be created

Issue: https://github.com/db-operator/db-operator/issues/41