### PR TITLE
build: Start testing against postgres 16

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -190,6 +190,7 @@ jobs:
     strategy:
       matrix:
         image:
+          - postgres:16
           - postgres:15
           - postgres:14
           - postgres:13


### PR DESCRIPTION
Postgres 16 was released, and I think we need to start testing against it