### PR TITLE
Make credentials in database optional

### DIFF
--- a/api/v1beta1/database_types.go
+++ b/api/v1beta1/database_types.go
@@ -32,7 +32,7 @@ type DatabaseSpec struct {
 	SecretsTemplates  map[string]string `json:"secretsTemplates,omitempty"`
 	Postgres          Postgres          `json:"postgres,omitempty"`
 	Cleanup           bool              `json:"cleanup,omitempty"`
-	Credentials       Credentials       `json:"credentials"`
+	Credentials       Credentials       `json:"credentials,omitempty"`
 }
 
 // Postgres struct should be used to provide resource that only applicable to postgres

--- a/config/crd/bases/kinda.rocks_databases.yaml
+++ b/config/crd/bases/kinda.rocks_databases.yaml
@@ -431,7 +431,6 @@ spec:
                 type: object
             required:
             - backup
-            - credentials
             - deletionProtected
             - instance
             - secretName


### PR DESCRIPTION
We're adding them to the current API version, so it shouldn't be a breaking change. So this field has to be optional.

I've checked that the templating logic still works with credentials unset, though I'm not sure why there is no pani...