### PR TITLE
Fix validation wehook for creds templates

### DIFF
--- a/api/v1beta1/database_webhook.go
+++ b/api/v1beta1/database_webhook.go
@@ -130,7 +130,7 @@ func ValidateSecretTemplates(templates map[string]string) error {
 	return nil
 }
 
-var helpers []string = []string{"Protocol", "Host", "Port", "Password", "Username", "Password", "Database"}
+var helpers []string = []string{"Protocol", "Hostname", "Port", "Password", "Username", "Password", "Database"}
 var functions []string = []string{"Secret", "ConfigMap", "Query"}
 
 func ValidateTemplates(templates Templates) error {

--- a/api/v1beta1/database_webhook_test.go
+++ b/api/v1beta1/database_webhook_test.go
@@ -37,11 +37,11 @@ func TestUnitSecretTemplatesValidator(t *testing.T) {
 
 func TestUnitTemplatesValidator(t *testing.T) {
 	validTemplates := v1beta1.Templates{
-		{ Name: "TEMPLATE_1", Template: "{{ .Protocol }} {{ .Host }} {{ .Port }} {{ .Username }} {{ .Password }} {{ .Database }}"},
+		{ Name: "TEMPLATE_1", Template: "{{ .Protocol }} {{ .Hostname }} {{ .Port }} {{ .Username }} {{ .Password }} {{ .Database }}"},
 		{ Name: "TEMPLATE_2", Template: "{{.Protocol }}"},
 		{ Name: "TEMPLATE_3", Template: "{{.Protocol }}"},
 		{ Name: "TEMPLATE_4", Template: "{{.Protocol}}"},
-		{ Name: "TEMPLATE_5", Template: "jdbc:{{ .Protocol }}://{{ .Username }}:{{ .Password }}@{{ .Host }}:{{ .Port }}/{{ .Database }}"},
+		{ Name: "TEMPLATE_5", Template: "jdbc:{{ .Protocol }}://{{ .Username }}:{{ .Password }}@{{ .Hostname }}:{{ .Port }}/{{ .Database }}"},
 		{ Name: "TEMPLATE_6", Template: "{{ .Secret \"CHECK\" }}"},
 		{ Name: "TEMPLATE_7", Template: "{{ .ConfigMap \"CHECK\" }}"},
 		{ Name: "TEMPLATE_8", Template: "{{ .Query \"CHECK\" }}"},


### PR DESCRIPTION
The helper that is getting dbin hostname is actually called `Hostname`, so the validation is broken