### PR TITLE
Grant each role to the admin user

### DIFF
--- a/.github/workflows/image-publish-dev.yaml
+++ b/.github/workflows/image-publish-dev.yaml
@@ -1,0 +1,100 @@
+name: Publish Dev Docker image
+
+on:
+  push:
+
+env:
+  manufacturer: db-operator
+  product_name: db-operator
+  go_version: "1.20"
+  go_os: linux
+  main_go_path: ./cmd/main.go
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - go_arch: "amd64"
+            docker_arch: "amd64"
+          - go_arch: "arm64"
+            docker_arch: "arm64/v8"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.go_version }}
+      
+      - name: Compile Binary
+        env:
+          GOOS: ${{ env.go_os }}
+          GOARCH: ${{ matrix.go_arch }}
+          CGO_ENABLED: "0"
+        run: |
+          go build -tags build -o ${{ env.product_name }} ${{ env.main_go_path }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set action link variable
+        run: echo "LINK=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> $GITHUB_ENV
+
+      - name: Build and export
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          context: .
+          file: Dockerfile-ci
+          platforms: ${{ env.go_os }}/${{ matrix.docker_arch }}
+          tags: |
+            ghcr.io/${{ env.manufacturer }}/${{ env.product_name }}-dev:latest-${{ matrix.go_arch }}
+            ghcr.io/${{ env.manufacturer }}/${{ env.product_name }}-dev:v${{ github.sha }}-${{ matrix.go_arch }}
+          labels: |
+            action_link=${{ env.LINK }}
+            actor=${{ github.actor }}
+            sha=${{ github.sha }}
+            ref=${{ github.ref }}
+
+  push_to_ghcr:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create a docker manifest for a versioned container
+        run: |
+          docker manifest create ghcr.io/${{ env.manufacturer }}/${{ env.product_name }}-dev:v${{ github.sha }} \
+            --amend ghcr.io/${{ env.manufacturer }}/${{ env.product_name }}-dev:v${{ github.sha }}-amd64 \
+            --amend ghcr.io/${{ env.manufacturer }}/${{ env.product_name }}-dev:v${{ github.sha }}-arm64
+
+      - name: Create a manifest for the latest container
+        run: |
+          docker manifest create ghcr.io/${{ env.manufacturer }}/${{ env.product_name }}-dev:latest \
+            --amend ghcr.io/${{ env.manufacturer }}/${{ env.product_name }}-dev:latest-amd64 \
+            --amend ghcr.io/${{ env.manufacturer }}/${{ env.product_name }}-dev:latest-arm64
+
+      - name: Push the manifest
+        run: |
+          docker manifest push ghcr.io/${{ env.manufacturer }}/${{ env.product_name }}-dev:v${{ github.sha }}
+          docker manifest push ghcr.io/${{ env.manufacturer }}/${{ env.product_name }}-dev:latest 


### PR DESCRIPTION
1. I've added one more workflow, so on each push we have a container image. Sometimes I can't test using the locally built image, so it would help. It should be gone when this PR can be merged: https://github.com/db-operator/db-operator/pull/23
2. Granting role to the admin seems to be a requirement for granting permissions on tables on Azure. If someone is not happy with having this kind of setup, we can make it optional and set on the `DbInstance` level