### PR TITLE
Wrap schema names with quotes in Postgres

### DIFF
--- a/pkg/utils/database/postgres.go
+++ b/pkg/utils/database/postgres.go
@@ -160,7 +160,7 @@ func (p Postgres) dropPublicSchema(admin *DatabaseUser) error {
 
 func (p Postgres) createSchemas(ac4tor *DatabaseUser) error {
 	for _, s := range p.Schemas {
-		createSchema := fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", s)
+		createSchema := fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS \"%s\";", s)
 		if err := p.executeExec(p.Database, createSchema, ac4tor); err != nil {
 			logrus.Errorf("failed to create schema %s, %s", s, err)
 			return err

--- a/pkg/utils/database/postgres_test.go
+++ b/pkg/utils/database/postgres_test.go
@@ -420,7 +420,7 @@ func TestPostgresNoSchemas(t *testing.T) {
 func TestPostgresSchemas(t *testing.T) {
 	admin := getPostgresAdmin()
 	p, dbu := testPostgres()
-	p.Schemas = []string{"schema_1", "schema_2"}
+	p.Schemas = []string{"schema_1", "schema_2", "schema-3"}
 
 	assert.Error(t, p.checkSchemas(dbu))
 	assert.NoError(t, p.createSchemas(admin))


### PR DESCRIPTION
When schemas are being created, they should be also wrapped with quotes, like databases and extensions, to make it possible to give them names containing dashes

Issue: https://github.com/db-operator/db-operator/issues/94