### PR TITLE
Fix the memory leak

### DIFF
--- a/internal/controller/database_controller.go
+++ b/internal/controller/database_controller.go
@@ -717,7 +717,6 @@ func (r *DatabaseReconciler) handleProxy(ctx context.Context, dbcr *kindav1beta1
 // secrets and configmaps, so it's a generic function that can be used for both:
 // creating and removing
 func (r *DatabaseReconciler) handleTemplatedCredentials(ctx context.Context, dbcr *kindav1beta1.Database) error {
-	log := log.FromContext(ctx)
 	databaseSecret, err := r.getDatabaseSecret(ctx, dbcr)
 	if err != nil {
 		return err
@@ -744,7 +743,7 @@ func (r *DatabaseReconciler) handleTemplatedCredentials(ctx context.Context, dbc
 		return err
 	}
 
-	templateds, err := templates.NewTemplateDataSource(dbcr, nil, databaseSecret, databaseConfigMap, db, dbuser, log)
+	templateds, err := templates.NewTemplateDataSource(dbcr, nil, databaseSecret, databaseConfigMap, db, dbuser)
 	if err != nil {
 		return err
 	}

--- a/internal/controller/database_controller.go
+++ b/internal/controller/database_controller.go
@@ -766,7 +766,8 @@ func (r *DatabaseReconciler) handleTemplatedCredentials(ctx context.Context, dbc
 	if err := r.kubeHelper.HandleCreateOrUpdate(ctx, templateds.ConfigMapK8sObj); err != nil {
 		return err
 	}
-
+	// Set it to nil explicitly to ensure it's picked up by the GC
+	templateds = nil
 	return nil
 }
 

--- a/internal/controller/dbuser_controller.go
+++ b/internal/controller/dbuser_controller.go
@@ -335,7 +335,6 @@ func (r *DbUserReconciler) getAdminSecret(ctx context.Context, dbcr *kindav1beta
 // creating and removing
 // It's mostly a copy-paste from the database controller, maybe it might be refactored
 func (r *DbUserReconciler) handleTemplatedCredentials(ctx context.Context, dbcr *kindav1beta1.Database, dbusercr *v1beta1.DbUser, dbuser *database.DatabaseUser) error {
-	log := log.FromContext(ctx)
 	databaseSecret, err := r.getDbUserSecret(ctx, dbusercr)
 	if err != nil {
 		return err
@@ -362,7 +361,7 @@ func (r *DbUserReconciler) handleTemplatedCredentials(ctx context.Context, dbcr 
 		return err
 	}
 
-	templateds, err := templates.NewTemplateDataSource(dbcr, dbusercr, databaseSecret, databaseConfigMap, db, dbuser, log)
+	templateds, err := templates.NewTemplateDataSource(dbcr, dbusercr, databaseSecret, databaseConfigMap, db, dbuser)
 	if err != nil {
 		return err
 	}

--- a/internal/controller/dbuser_controller.go
+++ b/internal/controller/dbuser_controller.go
@@ -380,6 +380,9 @@ func (r *DbUserReconciler) handleTemplatedCredentials(ctx context.Context, dbcr 
 	if err := r.kubeHelper.HandleCreateOrUpdate(ctx, templateds.SecretK8sObj); err != nil {
 		return err
 	}
+	
+	// Set it to nil explicitly to ensure it's picked up by the GC
+	templateds = nil
 
 	return nil
 }

--- a/internal/utils/templates/templates.go
+++ b/internal/utils/templates/templates.go
@@ -28,7 +28,6 @@ import (
 	"github.com/db-operator/db-operator/pkg/consts"
 	"github.com/db-operator/db-operator/pkg/types"
 	"github.com/db-operator/db-operator/pkg/utils/database"
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 
 	"k8s.io/utils/strings/slices"
@@ -134,7 +133,6 @@ type TemplateDataSources struct {
 	ConfigMapK8sObj *corev1.ConfigMap
 	DatabaseObj     database.Database
 	DatabaseUser    *database.DatabaseUser
-	Log             logr.Logger
 }
 
 // NewTemplateDataSource is used to init the struct that should handle the templating of secrets and other key-values
@@ -147,7 +145,6 @@ func NewTemplateDataSource(
 	configmapK8s *corev1.ConfigMap,
 	db database.Database,
 	databaseUser *database.DatabaseUser,
-	log logr.Logger,
 ) (*TemplateDataSources, error) {
 	if databaseK8s == nil {
 		return nil, errors.New("database must be passed")
@@ -191,7 +188,6 @@ func NewTemplateDataSource(
 		ConfigMapK8sObj: configmapK8s,
 		DatabaseObj:     db,
 		DatabaseUser:    databaseUser,
-		Log:             log,
 	}, nil
 }
 
@@ -220,7 +216,6 @@ func (tds *TemplateDataSources) ConfigMap(entry string) (string, error) {
 
 // Get the data directly from the database
 func (tds *TemplateDataSources) Query(query string) (string, error) {
-	tds.Log.Info("Querying data from database is experimental, use cautiously and feel free to create github issues")
 	result, err := tds.DatabaseObj.QueryAsUser(context.TODO(), query, tds.DatabaseUser)
 	if err != nil {
 		return "", err

--- a/internal/utils/templates/templates_test.go
+++ b/internal/utils/templates/templates_test.go
@@ -91,7 +91,7 @@ var dbuserK8s *v1beta1.DbUser = &v1beta1.DbUser{
 var db database.Database = database.New("dummy")
 
 func TestUnitNewDSDatabase(t *testing.T) {
-	templateds, err := templates.NewTemplateDataSource(databaseK8s, nil, secretK8s, configmapK8s, db, nil, log)
+	templateds, err := templates.NewTemplateDataSource(databaseK8s, nil, secretK8s, configmapK8s, db, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, &templates.TemplateDataSources{
 		DatabaseK8sObj:  databaseK8s,
@@ -104,7 +104,7 @@ func TestUnitNewDSDatabase(t *testing.T) {
 }
 
 func TestUnitNewDSDatabaseUser(t *testing.T) {
-	templateds, err := templates.NewTemplateDataSource(databaseK8s, dbuserK8s, secretK8sUser, configmapK8s, db, nil, log)
+	templateds, err := templates.NewTemplateDataSource(databaseK8s, dbuserK8s, secretK8sUser, configmapK8s, db, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, &templates.TemplateDataSources{
 		DatabaseK8sObj:  databaseK8s,
@@ -119,46 +119,46 @@ func TestUnitNewDSDatabaseUser(t *testing.T) {
 func TestUnitNewDSSecretOwnershipError(t *testing.T) {
 	newSecret := secretK8s.DeepCopy()
 	newSecret.ObjectMeta.Name = "newname"
-	_, err := templates.NewTemplateDataSource(databaseK8s, nil, newSecret, configmapK8s, db, nil, log)
+	_, err := templates.NewTemplateDataSource(databaseK8s, nil, newSecret, configmapK8s, db, nil)
 	assert.Error(t, errors.New("secret newname doesn't belong to the database database"), err)
 }
 
 func TestUnitNewDSSecretOwnershipUserError(t *testing.T) {
 	newSecret := secretK8s.DeepCopy()
 	newSecret.ObjectMeta.Name = "creds"
-	_, err := templates.NewTemplateDataSource(databaseK8s, dbuserK8s, newSecret, configmapK8s, db, nil, log)
+	_, err := templates.NewTemplateDataSource(databaseK8s, dbuserK8s, newSecret, configmapK8s, db, nil)
 	assert.Error(t, errors.New("secret creds doesn't belong to the DbUser dbuser"), err)
 }
 
 func TestUnitNewDSSecretNotPassedError(t *testing.T) {
-	_, err := templates.NewTemplateDataSource(databaseK8s, nil, nil, configmapK8s, db, nil, log)
+	_, err := templates.NewTemplateDataSource(databaseK8s, nil, nil, configmapK8s, db, nil)
 	assert.Error(t, errors.New("secret must be passed"), err)
 }
 
 func TestUnitNewDSConfigMapOwnershipError(t *testing.T) {
 	newConfigmap := configmapK8s.DeepCopy()
 	newConfigmap.ObjectMeta.Name = "newname"
-	_, err := templates.NewTemplateDataSource(databaseK8s, nil, secretK8s, newConfigmap, db, nil, log)
+	_, err := templates.NewTemplateDataSource(databaseK8s, nil, secretK8s, newConfigmap, db, nil)
 	assert.Error(t, errors.New("configmap newname doesn't belong to the database database"), err)
 }
 
 func TestUnitNewDSConfigMapOwnershipUserNoError(t *testing.T) {
-	_, err := templates.NewTemplateDataSource(databaseK8s, dbuserK8s, secretK8sUser, configmapK8s, db, nil, log)
+	_, err := templates.NewTemplateDataSource(databaseK8s, dbuserK8s, secretK8sUser, configmapK8s, db, nil)
 	assert.NoError(t, err)
 }
 
 func TestUnitNewDSConfigMapNotPassedError(t *testing.T) {
-	_, err := templates.NewTemplateDataSource(databaseK8s, nil, secretK8s, nil, db, nil, log)
+	_, err := templates.NewTemplateDataSource(databaseK8s, nil, secretK8s, nil, db, nil)
 	assert.Error(t, errors.New("configmap must be passed"), err)
 }
 
 func TestUnitNewDSDatabaseNotPassedError(t *testing.T) {
-	_, err := templates.NewTemplateDataSource(nil, nil, secretK8s, configmapK8s, db, nil, log)
+	_, err := templates.NewTemplateDataSource(nil, nil, secretK8s, configmapK8s, db, nil)
 	assert.Error(t, errors.New("database must be passed"), err)
 }
 
 func TestUnitTemplatesSecret(t *testing.T) {
-	templateds, err := templates.NewTemplateDataSource(databaseK8s, nil, secretK8s, configmapK8s, db, nil, log)
+	templateds, err := templates.NewTemplateDataSource(databaseK8s, nil, secretK8s, configmapK8s, db, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -170,7 +170,7 @@ func TestUnitTemplatesSecret(t *testing.T) {
 }
 
 func TestUnitTemplatesSecretErr(t *testing.T) {
-	templateds, err := templates.NewTemplateDataSource(databaseK8s, nil, secretK8s, configmapK8s, db, nil, log)
+	templateds, err := templates.NewTemplateDataSource(databaseK8s, nil, secretK8s, configmapK8s, db, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -179,7 +179,7 @@ func TestUnitTemplatesSecretErr(t *testing.T) {
 }
 
 func TestUnitTemplatesConfigMap(t *testing.T) {
-	templateds, err := templates.NewTemplateDataSource(databaseK8s, nil, secretK8s, configmapK8s, db, nil, log)
+	templateds, err := templates.NewTemplateDataSource(databaseK8s, nil, secretK8s, configmapK8s, db, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -196,7 +196,7 @@ func TestUnitTemplatesQueryErr(t *testing.T) {
 		Error: err,
 	}
 
-	templateds, err := templates.NewTemplateDataSource(databaseK8s, nil, secretK8s, configmapK8s, dbNew, nil, log)
+	templateds, err := templates.NewTemplateDataSource(databaseK8s, nil, secretK8s, configmapK8s, dbNew, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -206,7 +206,7 @@ func TestUnitTemplatesQueryErr(t *testing.T) {
 
 func TestUnitTemplatesQuery(t *testing.T) {
 	query := "SELECT SOMETHING FROM SOMETHING"
-	templateds, err := templates.NewTemplateDataSource(databaseK8s, nil, secretK8s, configmapK8s, db, nil, log)
+	templateds, err := templates.NewTemplateDataSource(databaseK8s, nil, secretK8s, configmapK8s, db, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -218,7 +218,7 @@ func TestUnitTemplatesQuery(t *testing.T) {
 }
 
 func TestUnitTemplatesConfigMapErr(t *testing.T) {
-	templateds, err := templates.NewTemplateDataSource(databaseK8s, nil, secretK8s, configmapK8s, db, nil, log)
+	templateds, err := templates.NewTemplateDataSource(databaseK8s, nil, secretK8s, configmapK8s, db, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -241,7 +241,7 @@ var mysqlInstance *v1beta1.DbInstance = &v1beta1.DbInstance{
 func TestUnitProtocolGetterPostgres(t *testing.T) {
 	databaseNew := databaseK8s.DeepCopy()
 	databaseNew.Status.Engine = consts.ENGINE_POSTGRES
-	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretK8s, configmapK8s, db, nil, log)
+	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretK8s, configmapK8s, db, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -255,7 +255,7 @@ func TestUnitProtocolGetterPostgres(t *testing.T) {
 func TestUnitProtocolGetterMysql(t *testing.T) {
 	databaseNew := databaseK8s.DeepCopy()
 	databaseNew.Status.Engine = consts.ENGINE_MYSQL
-	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretK8s, configmapK8s, db, nil, log)
+	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretK8s, configmapK8s, db, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -293,7 +293,7 @@ var secretMysql *corev1.Secret = &corev1.Secret{
 func TestUnitUsernameGetterPostgres(t *testing.T) {
 	databaseNew := databaseK8s.DeepCopy()
 	databaseNew.Status.Engine = consts.ENGINE_POSTGRES
-	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretPostgres, configmapK8s, db, nil, log)
+	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretPostgres, configmapK8s, db, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -307,7 +307,7 @@ func TestUnitUsernameGetterPostgres(t *testing.T) {
 func TestUnitUsernameGetterMysql(t *testing.T) {
 	databaseNew := databaseK8s.DeepCopy()
 	databaseNew.Status.Engine = consts.ENGINE_MYSQL
-	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretMysql, configmapK8s, db, nil, log)
+	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretMysql, configmapK8s, db, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -321,14 +321,14 @@ func TestUnitUsernameGetterMysql(t *testing.T) {
 func TestUnitUsernameGetterUnknownEngineError(t *testing.T) {
 	databaseNew := databaseK8s.DeepCopy()
 	databaseNew.Status.Engine = "dymmysql"
-	_, err := templates.NewTemplateDataSource(databaseNew, nil, secretK8s, configmapK8s, db, nil, log)
+	_, err := templates.NewTemplateDataSource(databaseNew, nil, secretK8s, configmapK8s, db, nil)
 	assert.Error(t, errors.New("unknown engine: fake"), err)
 }
 
 func TestUnitPasswordGetterPostgres(t *testing.T) {
 	databaseNew := databaseK8s.DeepCopy()
 	databaseNew.Status.Engine = consts.ENGINE_POSTGRES
-	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretPostgres, configmapK8s, db, nil, log)
+	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretPostgres, configmapK8s, db, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -342,7 +342,7 @@ func TestUnitPasswordGetterPostgres(t *testing.T) {
 func TestUnitPasswordGetterMysql(t *testing.T) {
 	databaseNew := databaseK8s.DeepCopy()
 	databaseNew.Status.Engine = consts.ENGINE_MYSQL
-	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretMysql, configmapK8s, db, nil, log)
+	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretMysql, configmapK8s, db, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -356,14 +356,14 @@ func TestUnitPasswordGetterMysql(t *testing.T) {
 func TestUnitPasswordGetterUnknownEngineError(t *testing.T) {
 	databaseNew := databaseK8s.DeepCopy()
 	databaseNew.Status.Engine = "dymmysql"
-	_, err := templates.NewTemplateDataSource(databaseNew, nil, secretK8s, configmapK8s, db, nil, log)
+	_, err := templates.NewTemplateDataSource(databaseNew, nil, secretK8s, configmapK8s, db, nil)
 	assert.Error(t, errors.New("unknown engine: fake"), err)
 }
 
 func TestUnitDatabaseGetterPostgres(t *testing.T) {
 	databaseNew := databaseK8s.DeepCopy()
 	databaseNew.Status.Engine = consts.ENGINE_POSTGRES
-	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretPostgres, configmapK8s, db, nil, log)
+	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretPostgres, configmapK8s, db, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -377,7 +377,7 @@ func TestUnitDatabaseGetterPostgres(t *testing.T) {
 func TestUnitDatabaseGetterMysql(t *testing.T) {
 	databaseNew := databaseK8s.DeepCopy()
 	databaseNew.Status.Engine = consts.ENGINE_MYSQL
-	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretMysql, configmapK8s, db, nil, log)
+	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretMysql, configmapK8s, db, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -391,13 +391,13 @@ func TestUnitDatabaseGetterMysql(t *testing.T) {
 func TestUnitDatabaseGetterUnknownEngineError(t *testing.T) {
 	databaseNew := databaseK8s.DeepCopy()
 	databaseNew.Status.Engine = "dymmysql"
-	_, err := templates.NewTemplateDataSource(databaseNew, nil, secretK8s, configmapK8s, db, nil, log)
+	_, err := templates.NewTemplateDataSource(databaseNew, nil, secretK8s, configmapK8s, db, nil)
 	assert.Error(t, errors.New("unknown engine: fake"), err)
 }
 
 func TestUnitHostGetterNoProxy(t *testing.T) {
 	databaseNew := databaseK8s.DeepCopy()
-	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretMysql, configmapK8s, db, nil, log)
+	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretMysql, configmapK8s, db, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -413,7 +413,7 @@ func TestUnitHostGetterProxy(t *testing.T) {
 	databaseNew := databaseK8s.DeepCopy()
 	databaseNew.Status.ProxyStatus.Status = true
 	databaseNew.Status.ProxyStatus.ServiceName = expecterHostname
-	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretMysql, configmapK8s, db, nil, log)
+	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretMysql, configmapK8s, db, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -426,7 +426,7 @@ func TestUnitHostGetterProxy(t *testing.T) {
 
 func TestUnitPortGetterNoProxy(t *testing.T) {
 	databaseNew := databaseK8s.DeepCopy()
-	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretMysql, configmapK8s, db, nil, log)
+	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretMysql, configmapK8s, db, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -442,7 +442,7 @@ func TestUnitPortGetterProxy(t *testing.T) {
 	databaseNew := databaseK8s.DeepCopy()
 	databaseNew.Status.ProxyStatus.Status = true
 	databaseNew.Status.ProxyStatus.SQLPort = expectedPort
-	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretMysql, configmapK8s, db, nil, log)
+	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretMysql, configmapK8s, db, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -456,7 +456,7 @@ func TestUnitPortGetterProxy(t *testing.T) {
 func TestUnitRenderErrDupSecret(t *testing.T) {
 	databaseNew := databaseK8s.DeepCopy()
 	databaseNew.Status.Engine = consts.ENGINE_POSTGRES
-	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretPostgres, configmapK8s, db, database.NewDummyUser("mainUser"), log)
+	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretPostgres, configmapK8s, db, database.NewDummyUser("mainUser"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -483,7 +483,7 @@ func TestUnitRenderAppendCustomSecret(t *testing.T) {
 	}
 	databaseNew := databaseK8s.DeepCopy()
 	databaseNew.Status.Engine = consts.ENGINE_POSTGRES
-	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretPostgres.DeepCopy(), configmapK8s.DeepCopy(), db, database.NewDummyUser("mainUser"), log)
+	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretPostgres.DeepCopy(), configmapK8s.DeepCopy(), db, database.NewDummyUser("mainUser"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -534,7 +534,7 @@ func TestUnitRenderCleanupSecret(t *testing.T) {
 
 	databaseNew := databaseK8s.DeepCopy()
 	databaseNew.Status.Engine = consts.ENGINE_POSTGRES
-	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretNew, configmapK8s.DeepCopy(), db, database.NewDummyUser("mainUser"), log)
+	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretNew, configmapK8s.DeepCopy(), db, database.NewDummyUser("mainUser"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -570,7 +570,7 @@ func TestUnitRenderCleanupSecret(t *testing.T) {
 func TestUnitRenderErrDupConfigMap(t *testing.T) {
 	databaseNew := databaseK8s.DeepCopy()
 	databaseNew.Status.Engine = consts.ENGINE_POSTGRES
-	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretPostgres, configmapK8s, db, database.NewDummyUser("mainUser"), log)
+	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretPostgres, configmapK8s, db, database.NewDummyUser("mainUser"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -597,7 +597,7 @@ func TestUnitRenderAppendCustomConfigMap(t *testing.T) {
 	}
 	databaseNew := databaseK8s.DeepCopy()
 	databaseNew.Status.Engine = consts.ENGINE_POSTGRES
-	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretPostgres.DeepCopy(), configmapK8s.DeepCopy(), db, database.NewDummyUser("mainUser"), log)
+	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretPostgres.DeepCopy(), configmapK8s.DeepCopy(), db, database.NewDummyUser("mainUser"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -644,7 +644,7 @@ func TestUnitRenderCleanupConfigmMap(t *testing.T) {
 
 	databaseNew := databaseK8s.DeepCopy()
 	databaseNew.Status.Engine = consts.ENGINE_POSTGRES
-	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretPostgres, configmapK8s.DeepCopy(), db, database.NewDummyUser("mainUser"), log)
+	templateds, err := templates.NewTemplateDataSource(databaseNew, nil, secretPostgres, configmapK8s.DeepCopy(), db, database.NewDummyUser("mainUser"))
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
It's supposed to fix this issue: https://github.com/db-operator/db-operator/issues/106

I wasn't able to test on such a high load yet, but on my installation with 30 databases, I could spot a memory leak before this change. After a version with this fix was deployed, a leak was gone, so I'd give it a try