### PR TITLE
fix time unit for default reconcile interval

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -121,7 +121,7 @@ func main() {
 		interval := os.Getenv("RECONCILE_INTERVAL")
 		i, err := strconv.ParseInt(interval, 10, 64)
 		if err != nil {
-			i = 60
+			i = int64(60 * time.Second)
 			setupLog.Info("Set default reconcile period for database-controller", "time", interval)
 		}
 


### PR DESCRIPTION
The default value of `60` is passed to `time.Duration` which interprets this value as nanoseconds. I'm kinda assuming that this was meant to be 60 seconds (== 1min) instead. Our current observation is that 60 nanos is way to fast as a default value because it blows up the log output.