### PR TITLE
fix(db-operator): replaced the use of priveleges by privileges

### DIFF
--- a/api/v1beta1/dbinstance_types.go
+++ b/api/v1beta1/dbinstance_types.go
@@ -32,8 +32,8 @@ type DbInstanceSpec struct {
 	Backup          DbInstanceBackup        `json:"backup,omitempty"`
 	Monitoring      DbInstanceMonitoring    `json:"monitoring,omitempty"`
 	SSLConnection   DbInstanceSSLConnection `json:"sslConnection,omitempty"`
-	// A list of priveleges that are allowed to be set as Dbuser's extra priveleges
-	AllowedPriveleges []string `json:"allowedPriveleges,omitempty"`
+	// A list of privileges that are allowed to be set as Dbuser's extra privileges
+	AllowedPrivileges []string `json:"allowedPrivileges,omitempty"`
 	DbInstanceSource  `json:",inline"`
 }
 

--- a/api/v1beta1/dbinstance_webhook.go
+++ b/api/v1beta1/dbinstance_webhook.go
@@ -54,9 +54,9 @@ func (r *DbInstance) Default() {
 
 var _ webhook.Validator = &DbInstance{}
 
-func TestAllowedPrivileges(priveleges []string) error {
-	for _, privelege := range priveleges {
-		if strings.ToUpper(privelege) == consts.ALL_PRIVILEGES {
+func TestAllowedPrivileges(privileges []string) error {
+	for _, privilege := range privileges {
+		if strings.ToUpper(privilege) == consts.ALL_PRIVILEGES {
 			return errors.New("it's not allowed to grant ALL PRIVILEGES")
 		}
 	}
@@ -65,7 +65,7 @@ func TestAllowedPrivileges(priveleges []string) error {
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *DbInstance) ValidateCreate() (admission.Warnings, error) {
-	if err := TestAllowedPrivileges(r.Spec.AllowedPriveleges); err != nil {
+	if err := TestAllowedPrivileges(r.Spec.AllowedPrivileges); err != nil {
 		return nil, err
 	}
 
@@ -84,7 +84,7 @@ func (r *DbInstance) ValidateCreate() (admission.Warnings, error) {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *DbInstance) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
-	if err := TestAllowedPrivileges(r.Spec.AllowedPriveleges); err != nil {
+	if err := TestAllowedPrivileges(r.Spec.AllowedPrivileges); err != nil {
 		return nil, err
 	}
 

--- a/api/v1beta1/dbuser_webhook.go
+++ b/api/v1beta1/dbuser_webhook.go
@@ -62,9 +62,9 @@ func (r *DbUser) ValidateCreate() (admission.Warnings, error) {
 	return warnings, nil
 }
 
-func TestExtraPrivileges(priveleges []string) error {
-	for _, privelege := range priveleges {
-		if strings.ToUpper(privelege) == consts.ALL_PRIVILEGES {
+func TestExtraPrivileges(privileges []string) error {
+	for _, privilege := range privileges {
+		if strings.ToUpper(privilege) == consts.ALL_PRIVILEGES {
 			return errors.New("it's not allowed to grant ALL PRIVILEGES")
 		}
 	}
@@ -102,7 +102,7 @@ func (r *DbUser) ValidateUpdate(old runtime.Object) (admission.Warnings, error) 
 		if !slices.Contains(r.Spec.ExtraPrivileges, role) {
 			warnings = append(
 				warnings,
-				fmt.Sprintf("extra priveleges can't be removed by the operator, please manualy revoke %s from the user %s",
+				fmt.Sprintf("extra privileges can't be removed by the operator, please manualy revoke %s from the user %s",
 					role, r.Name),
 			)
 		}

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -329,8 +329,8 @@ func (in *DbInstanceSpec) DeepCopyInto(out *DbInstanceSpec) {
 	out.Backup = in.Backup
 	out.Monitoring = in.Monitoring
 	out.SSLConnection = in.SSLConnection
-	if in.AllowedPriveleges != nil {
-		in, out := &in.AllowedPriveleges, &out.AllowedPriveleges
+	if in.AllowedPrivileges != nil {
+		in, out := &in.AllowedPrivileges, &out.AllowedPrivileges
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/config/crd/bases/kinda.rocks_dbinstances.yaml
+++ b/config/crd/bases/kinda.rocks_dbinstances.yaml
@@ -236,9 +236,9 @@ spec:
                 - Name
                 - Namespace
                 type: object
-              allowedPriveleges:
-                description: A list of priveleges that are allowed to be set as Dbuser's
-                  extra priveleges
+              allowedPrivileges:
+                description: A list of privileges that are allowed to be set as Dbuser's
+                  extra privileges
                 items:
                   type: string
                 type: array

--- a/internal/controller/dbuser_controller.go
+++ b/internal/controller/dbuser_controller.go
@@ -126,9 +126,9 @@ func (r *DbUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err := r.Get(ctx, types.NamespacedName{Name: dbcr.Spec.Instance}, instance); err != nil {
 		return r.manageError(ctx, dbusercr, err, false)
 	}
-	// Check if chosen ExtraPriveleges are allowed on the instance
+	// Check if chosen ExtraPrivileges are allowed on the instance
 	for _, priv := range dbusercr.Spec.ExtraPrivileges {
-		if !slices.Contains(instance.Spec.AllowedPriveleges, priv) {
+		if !slices.Contains(instance.Spec.AllowedPrivileges, priv) {
 			err := fmt.Errorf("role %s is not allowed on the instance %s", priv, instance.Name)
 			return r.manageError(ctx, dbusercr, err, false)
 		}

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -57,6 +57,6 @@ const (
 	USED_BY_NAME_LABEL_KEY = "kinda.rocks/used-by-name"
 )
 
-// Priveleges
+// Privileges
 
 const ALL_PRIVILEGES = "ALL PRIVILEGES"

--- a/pkg/utils/database/postgres.go
+++ b/pkg/utils/database/postgres.go
@@ -49,7 +49,7 @@ type Postgres struct {
 	Schemas          []string
 	Template         string
 	// A user that is created with the Database
-	//  it's required to set default priveleges
+	//  it's required to set default privileges
 	//  for additional users
 	MainUser *DatabaseUser
 }
@@ -490,7 +490,7 @@ func (p Postgres) setUserPermission(ctx context.Context, admin *DatabaseUser, us
 		grant := fmt.Sprintf("GRANT ALL PRIVILEGES ON DATABASE \"%s\" TO \"%s\";", p.Database, user.Username)
 		err := p.executeExec(ctx, "postgres", grant, admin)
 		if err != nil {
-			log.Error(err, "failed granting all priveleges to user", "query", grant)
+			log.Error(err, "failed granting all privileges to user", "query", grant)
 			return err
 		}
 		grantCreateToAdmin := fmt.Sprintf("GRANT CREATE ON DATABASE \"%s\" to \"%s\";", p.Database, admin.Username)


### PR DESCRIPTION
Fixed invalid wording. It does affect the new parameter name, but better fix it before it might be used by others.