### PR TITLE
Update lima config to use latest Ubuntu LTS: Noble

### DIFF
--- a/resources/lima/k3s.yaml
+++ b/resources/lima/k3s.yaml
@@ -16,9 +16,9 @@ arch: "x86_64"
 
 images:
 # Hint: run `limactl prune` to invalidate the "current" cache
-- location: "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-amd64.img"
+- location: "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
   arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-arm64.img"
+- location: "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-arm64.img"
   arch: "aarch64"
 
 mounts: 


### PR DESCRIPTION
Impish is EOL & the images are no longer available.

Side note: do the tests currently all pass?  I'm getting many failures (lots of issues with user creation & looks like k8s might be an unspecified dependency?).

Thanks!