### PR TITLE
grant update to sequences for readwrite user

### DIFF
--- a/pkg/utils/database/postgres.go
+++ b/pkg/utils/database/postgres.go
@@ -549,8 +549,8 @@ func (p Postgres) setUserPermission(ctx context.Context, admin *DatabaseUser, us
 				s,
 				user.Username,
 			)
-			grantSequences := fmt.Sprintf("GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA \"%s\" TO \"%s\"", s, user.Username)
-			defaultPrivilegesSeq := fmt.Sprintf("ALTER DEFAULT PRIVILEGES FOR ROLE \"%s\" IN SCHEMA \"%s\" GRANT USAGE, SELECT ON SEQUENCES TO \"%s\";",
+			grantSequences := fmt.Sprintf("GRANT UPDATE, USAGE, SELECT ON ALL SEQUENCES IN SCHEMA \"%s\" TO \"%s\"", s, user.Username)
+			defaultPrivilegesSeq := fmt.Sprintf("ALTER DEFAULT PRIVILEGES FOR ROLE \"%s\" IN SCHEMA \"%s\" GRANT UPDATE, USAGE, SELECT ON SEQUENCES TO \"%s\";",
 				p.MainUser.Username,
 				s,
 				user.Username,

--- a/pkg/utils/database/postgres_test.go
+++ b/pkg/utils/database/postgres_test.go
@@ -268,8 +268,6 @@ func TestPostgresReadOnlyUserLifecycleNoAdminGrant(t *testing.T) {
 	assert.NoError(t, p.execAsUser(context.TODO(), selectQuery, readonlyUser))
 	selectQuery = "SELECT currval('permtest.test');"
 	assert.NoError(t, p.execAsUser(context.TODO(), selectQuery, readonlyUser))
-	selectQuery = "SELECT lastval();"
-	assert.NoError(t, p.execAsUser(context.TODO(), selectQuery, readonlyUser))
 	selectQuery = "SELECT setval('permtest.test', 10);"
 	assert.Error(t, p.execAsUser(context.TODO(), selectQuery, readonlyUser))
 
@@ -360,8 +358,6 @@ func TestPostgresReadWriteUserLifecycleNoAdminGrant(t *testing.T) {
 	selectQuery = "SELECT nextval('permtest.test');"
 	assert.NoError(t, p.execAsUser(context.TODO(), selectQuery, readwriteUser))
 	selectQuery = "SELECT currval('permtest.test');"
-	assert.NoError(t, p.execAsUser(context.TODO(), selectQuery, readwriteUser))
-	selectQuery = "SELECT lastval();"
 	assert.NoError(t, p.execAsUser(context.TODO(), selectQuery, readwriteUser))
 	selectQuery = "SELECT setval('permtest.test', 10);"
 	assert.NoError(t, p.execAsUser(context.TODO(), selectQuery, readwriteUser))

--- a/pkg/utils/database/postgres_test.go
+++ b/pkg/utils/database/postgres_test.go
@@ -266,8 +266,6 @@ func TestPostgresReadOnlyUserLifecycleNoAdminGrant(t *testing.T) {
 
 	selectQuery = "SELECT nextval('permtest.test');"
 	assert.NoError(t, p.execAsUser(context.TODO(), selectQuery, readonlyUser))
-	selectQuery = "SELECT currval('permtest.test');"
-	assert.NoError(t, p.execAsUser(context.TODO(), selectQuery, readonlyUser))
 	selectQuery = "SELECT setval('permtest.test', 10);"
 	assert.Error(t, p.execAsUser(context.TODO(), selectQuery, readonlyUser))
 
@@ -356,8 +354,6 @@ func TestPostgresReadWriteUserLifecycleNoAdminGrant(t *testing.T) {
 	assert.NoError(t, p.execAsUser(context.TODO(), update, readwriteUser))
 
 	selectQuery = "SELECT nextval('permtest.test');"
-	assert.NoError(t, p.execAsUser(context.TODO(), selectQuery, readwriteUser))
-	selectQuery = "SELECT currval('permtest.test');"
 	assert.NoError(t, p.execAsUser(context.TODO(), selectQuery, readwriteUser))
 	selectQuery = "SELECT setval('permtest.test', 10);"
 	assert.NoError(t, p.execAsUser(context.TODO(), selectQuery, readwriteUser))

--- a/pkg/utils/database/postgres_test.go
+++ b/pkg/utils/database/postgres_test.go
@@ -445,6 +445,8 @@ func TestPostgresReadOnlyUserLifecycleAdminGrant(t *testing.T) {
 
 	selectQuery = "SELECT nextval('permtest.test');"
 	assert.NoError(t, p.execAsUser(context.TODO(), selectQuery, readonlyUser))
+	selectQuery = "SELECT setval('permtest.test', 10);"
+	assert.Error(t, p.execAsUser(context.TODO(), selectQuery, readonlyUser))
 
 	delete := "DELETE FROM permtest.test_1 WHERE role_id = 1"
 	assert.Error(t, p.execAsUser(context.TODO(), delete, readonlyUser))
@@ -535,6 +537,8 @@ func TestPostgresReadWriteUserLifecycleAdminGrant(t *testing.T) {
 	update = "UPDATE permtest.test_2 SET role_name = 'test-1-new' WHERE role_id = 1"
 	assert.NoError(t, p.execAsUser(context.TODO(), update, readwriteUser))
 
+	selectQuery = "SELECT nextval('permtest.test');"
+	assert.NoError(t, p.execAsUser(context.TODO(), selectQuery, readwriteUser))
 	selectQuery = "SELECT nextval('permtest.test');"
 	assert.NoError(t, p.execAsUser(context.TODO(), selectQuery, readwriteUser))
 

--- a/pkg/utils/database/postgres_test.go
+++ b/pkg/utils/database/postgres_test.go
@@ -266,6 +266,12 @@ func TestPostgresReadOnlyUserLifecycleNoAdminGrant(t *testing.T) {
 
 	selectQuery = "SELECT nextval('permtest.test');"
 	assert.NoError(t, p.execAsUser(context.TODO(), selectQuery, readonlyUser))
+	selectQuery = "SELECT currval('permtest.test');"
+	assert.NoError(t, p.execAsUser(context.TODO(), selectQuery, readonlyUser))
+	selectQuery = "SELECT lastval();"
+	assert.NoError(t, p.execAsUser(context.TODO(), selectQuery, readonlyUser))
+	selectQuery = "SELECT setval('permtest.test', 10);"
+	assert.Error(t, p.execAsUser(context.TODO(), selectQuery, readonlyUser))
 
 	drop := "DROP TABLE permtest.test_1"
 	assert.Error(t, p.execAsUser(context.TODO(), drop, readonlyUser))
@@ -352,6 +358,12 @@ func TestPostgresReadWriteUserLifecycleNoAdminGrant(t *testing.T) {
 	assert.NoError(t, p.execAsUser(context.TODO(), update, readwriteUser))
 
 	selectQuery = "SELECT nextval('permtest.test');"
+	assert.NoError(t, p.execAsUser(context.TODO(), selectQuery, readwriteUser))
+	selectQuery = "SELECT currval('permtest.test');"
+	assert.NoError(t, p.execAsUser(context.TODO(), selectQuery, readwriteUser))
+	selectQuery = "SELECT lastval();"
+	assert.NoError(t, p.execAsUser(context.TODO(), selectQuery, readwriteUser))
+	selectQuery = "SELECT setval('permtest.test', 10);"
 	assert.NoError(t, p.execAsUser(context.TODO(), selectQuery, readwriteUser))
 
 	delete := "DELETE FROM permtest.test_1 WHERE role_id = 2"


### PR DESCRIPTION
Adding the update permission on sequences will allow the readwrite user to also update the sequence value.