### PR TITLE
Add truncate readwrite user

### DIFF
--- a/pkg/utils/database/postgres.go
+++ b/pkg/utils/database/postgres.go
@@ -543,8 +543,8 @@ func (p Postgres) setUserPermission(ctx context.Context, admin *DatabaseUser, us
 	case ACCESS_TYPE_READWRITE:
 		for _, s := range schemas {
 			grantUsage := fmt.Sprintf("GRANT USAGE ON SCHEMA \"%s\" TO \"%s\"", s, user.Username)
-			grantTables := fmt.Sprintf("GRANT SELECT, INSERT, DELETE, UPDATE ON ALL TABLES IN SCHEMA \"%s\" TO \"%s\"", s, user.Username)
-			defaultPrivileges := fmt.Sprintf("ALTER DEFAULT PRIVILEGES FOR ROLE \"%s\" IN SCHEMA \"%s\" GRANT SELECT, INSERT, DELETE, UPDATE ON TABLES TO \"%s\";",
+			grantTables := fmt.Sprintf("GRANT SELECT, INSERT, DELETE, UPDATE, TRUNCATE ON ALL TABLES IN SCHEMA \"%s\" TO \"%s\"", s, user.Username)
+			defaultPrivileges := fmt.Sprintf("ALTER DEFAULT PRIVILEGES FOR ROLE \"%s\" IN SCHEMA \"%s\" GRANT SELECT, INSERT, DELETE, UPDATE, TRUNCATE ON TABLES TO \"%s\";",
 				p.MainUser.Username,
 				s,
 				user.Username,

--- a/pkg/utils/database/postgres_test.go
+++ b/pkg/utils/database/postgres_test.go
@@ -1,4 +1,4 @@
-
+ /*
  * Copyright 2021 kloeckner.i GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/utils/database/postgres_test.go
+++ b/pkg/utils/database/postgres_test.go
@@ -1,4 +1,4 @@
-/*
+
  * Copyright 2021 kloeckner.i GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -259,6 +259,11 @@ func TestPostgresReadOnlyUserLifecycleNoAdminGrant(t *testing.T) {
 	update = "UPDATE permtest.test_2 SET role_name = 'test-1-new' WHERE role_id = 1"
 	assert.Error(t, p.execAsUser(context.TODO(), update, readonlyUser))
 
+	truncate := "TRUNCATE TABLE permtest.test_1"
+	assert.Error(t, p.execAsUser(context.TODO(), truncate, readonlyUser))
+	truncate = "TRUNCATE TABLE permtest.test_2"
+	assert.Error(t, p.execAsUser(context.TODO(), truncate, readonlyUser))
+
 	delete := "DELETE FROM permtest.test_1 WHERE role_id = 1"
 	assert.Error(t, p.execAsUser(context.TODO(), delete, readonlyUser))
 	delete = "DELETE FROM permtest.test_2 WHERE role_id = 1"
@@ -365,6 +370,11 @@ func TestPostgresReadWriteUserLifecycleNoAdminGrant(t *testing.T) {
 	assert.NoError(t, p.execAsUser(context.TODO(), delete, readwriteUser))
 	delete = "DELETE FROM permtest.test_2 WHERE role_id = 2"
 	assert.NoError(t, p.execAsUser(context.TODO(), delete, readwriteUser))
+
+	truncate := "TRUNCATE TABLE permtest.test_1"
+	assert.NoError(t, p.execAsUser(context.TODO(), truncate, readwriteUser))
+	truncate = "TRUNCATE TABLE permtest.test_2"
+	assert.NoError(t, p.execAsUser(context.TODO(), truncate, readwriteUser))
 
 	drop := "DROP TABLE permtest.test_1"
 	assert.Error(t, p.execAsUser(context.TODO(), drop, readwriteUser))

--- a/pkg/utils/database/postgres_test.go
+++ b/pkg/utils/database/postgres_test.go
@@ -1,4 +1,4 @@
- /*
+/*
  * Copyright 2021 kloeckner.i GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Truncate is a preferred option to delete all tabledata for larger tables,
as it generates no archivelog and is very fast. Only downsite is that it
cannot be roll-backed.