### PR TITLE
Allow using existing users for Databases and DbUsers

### DIFF
--- a/api/v1beta1/database_types.go
+++ b/api/v1beta1/database_types.go
@@ -36,6 +36,10 @@ type DatabaseSpec struct {
 	Cleanup           bool              `json:"cleanup,omitempty"`
 	Credentials       Credentials       `json:"credentials,omitempty"`
 	ExtraGrants       []*ExtraGrant     `json:"extraGrants,omitempty"`
+	// If specified, DB Operator will try to use an existing user to assign permissions
+	// User will not be removed, when a database is removed, but the permissions added by the
+	// operator will be cleaned up
+	ExistingUser string `json:"existingUser,omitempty"`
 }
 
 type ExtraGrant struct {

--- a/api/v1beta1/dbuser_types.go
+++ b/api/v1beta1/dbuser_types.go
@@ -50,6 +50,10 @@ type DbUserSpec struct {
 	// +kubebuilder:default=true
 	// +optional
 	GrantToAdmin bool `json:"grantToAdmin"`
+	// If specified, DB Operator will try to use an existing user to assign permissions
+	// User will not be removed, when a dbuser is removed, but the permissions added by the
+	// operator will be cleaned up
+	ExistingUser string `json:"existingUser,omitempty"`
 }
 
 // DbUserStatus defines the observed state of DbUser

--- a/config/crd/bases/kinda.rocks_databases.yaml
+++ b/config/crd/bases/kinda.rocks_databases.yaml
@@ -434,6 +434,12 @@ spec:
                 type: object
               deletionProtected:
                 type: boolean
+              existingUser:
+                description: |-
+                  If specified, DB Operator will try to use an existing user to assign permissions
+                  User will not be removed, when a database is removed, but the permissions added by the
+                  operator will be cleaned up
+                type: string
               extraGrants:
                 items:
                   properties:

--- a/config/crd/bases/kinda.rocks_dbusers.yaml
+++ b/config/crd/bases/kinda.rocks_dbusers.yaml
@@ -122,6 +122,12 @@ spec:
                   DatabaseRef should contain a name of a Database to create a user there
                   Database should be in the same namespace with the user
                 type: string
+              existingUser:
+                description: |-
+                  If specified, DB Operator will try to use an existing user to assign permissions
+                  User will not be removed, when a dbuser is removed, but the permissions added by the
+                  operator will be cleaned up
+                type: string
               extraPrivileges:
                 description: A list of additional roles that should be added to the
                   user

--- a/internal/webhook/v1beta1/database_webhook.go
+++ b/internal/webhook/v1beta1/database_webhook.go
@@ -128,6 +128,10 @@ func (v *DatabaseCustomValidator) ValidateUpdate(_ context.Context, oldObj, newO
 		}
 	}
 
+	if len(oldObj.Spec.ExistingUser) > 0 && len(newObj.Spec.ExistingUser) == 0 {
+		warnings = append(warnings, "After swtching from exsting user to a generated user, the password is set to an empty string, remove the db secret to generate it")
+	}
+
 	// Ensure fields are immutable
 	immutableErr := "cannot change %s, the field is immutable"
 	if newObj.Spec.Instance != oldObj.Spec.Instance {

--- a/internal/webhook/v1beta1/dbuser_webhook.go
+++ b/internal/webhook/v1beta1/dbuser_webhook.go
@@ -84,6 +84,11 @@ func (v *DbUserCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj
 	if err := TestExtraPrivileges(newObj.Spec.ExtraPrivileges); err != nil {
 		return warnings, err
 	}
+
+	if len(oldObj.Spec.ExistingUser) > 0 && len(newObj.Spec.ExistingUser) == 0 {
+		warnings = append(warnings, "After swtching from exsting user to a generated user, the password is set to an empty string, remove the db secret to generate it")
+	}
+
 	if err := kindarocksv1beta1.IsAccessTypeSupported(newObj.Spec.AccessType); err != nil {
 		return warnings, err
 	}

--- a/pkg/utils/database/postgres.go
+++ b/pkg/utils/database/postgres.go
@@ -674,8 +674,8 @@ func (p Postgres) setUserPermission(ctx context.Context, admin *DatabaseUser, us
 }
 
 func (p Postgres) revokePermissions(ctx context.Context, admin *DatabaseUser, user *DatabaseUser) error {
-	log := log.FromContext(ctx)
 	if user.AccessType != ACCESS_TYPE_MAINUSER && p.isUserExist(ctx, admin, user) {
+		log := log.FromContext(ctx)
 		schemas := p.Schemas
 		if !p.DropPublicSchema {
 			schemas = append(schemas, "public")
@@ -702,7 +702,7 @@ func (p Postgres) revokePermissions(ctx context.Context, admin *DatabaseUser, us
 				schema,
 				user.Username,
 			)
-			if err := p.executeExec(ctx, p.Database, revokeDefaults, p.MainUser); err != nil {
+			if err := p.executeExec(ctx, p.Database, revokeDefaults, admin); err != nil {
 				log.Error(err, "failed removing default privileges from schema", "username", user.Username, "schema", schema)
 				return err
 			}
@@ -716,7 +716,6 @@ func (p Postgres) revokePermissions(ctx context.Context, admin *DatabaseUser, us
 				log.Error(err, "failed dropping owned", "username", user.Username)
 				return err
 			}
-
 		}
 	}
 	return nil


### PR DESCRIPTION
With this change it should become possible to use existing users with
both enginges: mysql and postgres. DB Operator will not try to create or
update the user, it will only set and revoke permissions. So after a
database is removed, the user will stay on the server

Issue: https://github.com/db-operator/db-operator/issues/255

Signed-off-by: Nikolai Rodionov <iam@allanger.xyz>
