### PR TITLE
docs: fix allowedPriveleges typo in dbinstances.md

### DIFF
--- a/documentation/docs/dbinstances.md
+++ b/documentation/docs/dbinstances.md
@@ -103,7 +103,7 @@ To use the `.extraPrivileges` feature of `DbUsers`, you also need to enabled the
 ```yaml
 spec:
   generic:
-    allowedPriveleges:
+    allowedPrivileges:
       - readOnlyAdmin
       - rds-iam
 ```


### PR DESCRIPTION
Docs example uses `allowedPriveleges`, actual field is `allowedPrivileges` (checked against `internal/webhook/v1beta1/dbinstance_webhook.go`, that's the spelling the webhook/CRD actually validates against). Someone copy-pasting this example would get a silently-ignored field.

Fixes #410.