### PR TITLE
Fix DbUser deletion without credentials Secret

### DIFF
--- a/api/v1beta1/dbuser_types.go
+++ b/api/v1beta1/dbuser_types.go
@@ -60,6 +60,7 @@ type DbUserSpec struct {
 type DbUserStatus struct {
 	Status       bool   `json:"status"`
 	DatabaseName string `json:"database"`
+	UserName     string `json:"user,omitempty"`
 	// It's required to let the operator update users
 	Created         bool   `json:"created"`
 	OperatorVersion string `json:"operatorVersion,omitempty"`

--- a/config/crd/bases/kinda.rocks_dbusers.yaml
+++ b/config/crd/bases/kinda.rocks_dbusers.yaml
@@ -167,6 +167,8 @@ spec:
                 type: string
               status:
                 type: boolean
+              user:
+                type: string
             required:
             - created
             - database

--- a/internal/controller/dbuser_controller.go
+++ b/internal/controller/dbuser_controller.go
@@ -92,15 +92,13 @@ func (r *DbUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err := r.Get(ctx, types.NamespacedName{Namespace: req.Namespace, Name: dbusercr.Spec.DatabaseRef}, dbcr); err != nil {
 		return r.manageError(ctx, dbusercr, err, false)
 	}
+	if dbusercr.IsDeleted() {
+		return r.handleDbUserDelete(ctx, dbusercr, dbcr)
+	}
 
-	// The secret is required for all kinds of the events, because it's used a storage for the
-	// dbuser data. So even when a dbuser is removed, we need to get the secret in order to
-	// let the db-operator know which exactly user must be removed.
 	userSecret, err := r.getDbUserSecret(ctx, dbusercr)
 	if err != nil {
-		// If a secret is not found on the "delete" event it should be a critical unrecoverable
-		// error, cause we don't know which user must be removed
-		if k8serrors.IsNotFound(err) && !dbusercr.IsDeleted() {
+		if k8serrors.IsNotFound(err) {
 			dbName := fmt.Sprintf("%s-%s", dbusercr.Namespace, dbusercr.Spec.DatabaseRef)
 			secretData, err := dbhelper.GenerateDatabaseSecretData(dbusercr.ObjectMeta, dbcr.Status.Engine, dbName, dbusercr.Spec.ExistingUser)
 			if err != nil {
@@ -149,6 +147,9 @@ func (r *DbUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err != nil {
 		return r.manageError(ctx, dbusercr, err, false)
 	}
+	if dbusercr.Status.Status && dbusercr.Status.UserName == "" {
+		dbusercr.Status.UserName = creds.Username
+	}
 
 	// If we don't check for changes, status should be false on each reconciliation
 	if !r.CheckChanges || isDbUserChanged(dbusercr, userSecret) {
@@ -173,28 +174,7 @@ func (r *DbUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			return r.manageError(ctx, dbusercr, err, false)
 		}
 
-		val, ok := dbusercr.Annotations[consts.GRANT_TO_ADMIN_ON_DELETE]
-		if ok {
-			boolVal, err := strconv.ParseBool(val)
-			if err != nil {
-				log.Info(
-					"can't parse a value of an annotation into a bool, ignoring",
-					"annotation",
-					consts.GRANT_TO_ADMIN_ON_DELETE,
-					"value",
-					val,
-					"error",
-					err,
-				)
-			} else {
-				dbuser.GrantToAdminOnDelete = boolVal
-			}
-		}
-
-		// Add extra privileges
-		dbuser.ExtraPrivileges = dbusercr.Spec.ExtraPrivileges
-
-		dbuser.GrantToAdmin = dbusercr.Spec.GrantToAdmin
+		existingUser := configureDbUser(ctx, dbusercr, dbuser, creds)
 
 		adminSecretResource, err := r.getAdminSecret(ctx, dbcr)
 		if err != nil {
@@ -208,78 +188,26 @@ func (r *DbUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			return r.manageError(ctx, dbusercr, err, false)
 		}
 
-		dbuser.AccessType = dbusercr.Spec.AccessType
-		dbuser.Password = creds.Password
-		dbuser.Username = creds.Username
-		// If allow existing is set to true, db-operator will not force user creation
-		// and also when a user with that property is removed, user won't be removed
-		// from the database, instead only the permissions will be revoked
-		existingUser := false
-		// TODO: Remove this annotation
-		allowExistingRaw, ok := dbusercr.Annotations[consts.ALLOW_EXISTING_USER]
-		if ok {
-			log.Info("Annotation is deprecated, please use .spec.existingUser instead", "annotation", consts.ALLOW_EXISTING_USER)
-			existingUser, err = strconv.ParseBool(allowExistingRaw)
-			if err != nil {
-				log.Info(
-					"can't parse a value of an annotation into a bool, ignoring",
-					"annotation",
-					consts.ALLOW_EXISTING_USER,
-					"value",
-					allowExistingRaw,
-					"error",
-					err,
-				)
-			}
+		if !dbcr.Status.Status {
+			err := fmt.Errorf("database %s is not ready yet", dbcr.Name)
+			return r.manageError(ctx, dbusercr, err, true)
 		}
 
-		if len(dbusercr.Spec.ExistingUser) > 0 {
-			existingUser = true
-		}
-
-		if dbusercr.IsDeleted() {
-			if commonhelper.ContainsString(dbusercr.Finalizers, "dbuser."+dbusercr.Name) {
-				if err := r.handleTemplatedCredentials(ctx, dbcr, dbusercr, dbuser); err != nil {
-					return r.manageError(ctx, dbusercr, err, true)
-				}
-				if existingUser {
-					if err := database.RevokePermissions(ctx, db, dbuser, adminCred); err != nil {
-						log.Error(err, "failed revoking permissions")
-						return r.manageError(ctx, dbusercr, err, false)
-					}
-				} else {
-					if err := database.DeleteUser(ctx, db, dbuser, adminCred); err != nil {
-						log.Error(err, "failed deleting a user")
-						return r.manageError(ctx, dbusercr, err, false)
-					}
-				}
-				if err := r.kubeHelper.HandleDelete(ctx, userSecret); err != nil {
-					return r.manageError(ctx, dbusercr, err, false)
-				}
-				kci.RemoveFinalizer(&dbcr.ObjectMeta, "dbuser."+dbusercr.Name)
-				err = r.Update(ctx, dbcr)
-				if err != nil {
-					log.Error(err, "error resource updating")
-					return r.manageError(ctx, dbusercr, err, false)
-				}
-				kci.RemoveFinalizer(&dbusercr.ObjectMeta, "dbuser."+dbusercr.Name)
-				err = r.Update(ctx, dbusercr)
-				if err != nil {
-					log.Error(err, "error resource updating")
-					return r.manageError(ctx, dbusercr, err, false)
-				}
+		// If allow existing is set to true, always execute UpdateOrCreate,
+		// otherwise follow the old logic
+		if existingUser {
+			log.Info("existing user management is allowed")
+			if err := database.SetPermissions(ctx, db, dbuser, adminCred); err != nil {
+				return r.manageError(ctx, dbusercr, err, false)
 			}
+			if err = r.addFinalizers(ctx, dbusercr, dbcr); err != nil {
+				return r.manageError(ctx, dbusercr, err, false)
+			}
+			dbusercr.Status.Created = true
 		} else {
-			if !dbcr.Status.Status {
-				err := fmt.Errorf("database %s is not ready yet", dbcr.Name)
-				return r.manageError(ctx, dbusercr, err, true)
-			}
-
-			// If allow existing is set to true, always execute UpdateOrCreate,
-			// otherwise follow the old logic
-			if existingUser {
-				log.Info("existing user management is allowed")
-				if err := database.SetPermissions(ctx, db, dbuser, adminCred); err != nil {
+			if !dbusercr.Status.Created {
+				log.Info("creating a user", "name", dbusercr.GetName())
+				if err := database.CreateUser(ctx, db, dbuser, adminCred); err != nil {
 					return r.manageError(ctx, dbusercr, err, false)
 				}
 				if err = r.addFinalizers(ctx, dbusercr, dbcr); err != nil {
@@ -287,31 +215,157 @@ func (r *DbUserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 				}
 				dbusercr.Status.Created = true
 			} else {
-				if !dbusercr.Status.Created {
-					log.Info("creating a user", "name", dbusercr.GetName())
-					if err := database.CreateUser(ctx, db, dbuser, adminCred); err != nil {
-						return r.manageError(ctx, dbusercr, err, false)
-					}
-					if err = r.addFinalizers(ctx, dbusercr, dbcr); err != nil {
-						return r.manageError(ctx, dbusercr, err, false)
-					}
-					dbusercr.Status.Created = true
-				} else {
-					log.Info("updating a user", "name", dbusercr.GetName())
-					if err := database.UpdateUser(ctx, db, dbuser, adminCred); err != nil {
-						return r.manageError(ctx, dbusercr, err, false)
-					}
+				log.Info("updating a user", "name", dbusercr.GetName())
+				if err := database.UpdateUser(ctx, db, dbuser, adminCred); err != nil {
+					return r.manageError(ctx, dbusercr, err, false)
 				}
 			}
-			if err := r.handleTemplatedCredentials(ctx, dbcr, dbusercr, dbuser); err != nil {
-				return r.manageError(ctx, dbusercr, err, true)
-			}
-			dbusercr.Status.OperatorVersion = commonhelper.OperatorVersion
-			dbusercr.Status.Status = true
-			dbusercr.Status.DatabaseName = dbusercr.Spec.DatabaseRef
 		}
+		if err := r.handleTemplatedCredentials(ctx, dbcr, dbusercr, dbuser); err != nil {
+			return r.manageError(ctx, dbusercr, err, true)
+		}
+		dbusercr.Status.OperatorVersion = commonhelper.OperatorVersion
+		dbusercr.Status.Status = true
+		dbusercr.Status.DatabaseName = dbusercr.Spec.DatabaseRef
+		dbusercr.Status.UserName = creds.Username
 	}
 	return reconcileResult, nil
+}
+
+func (r *DbUserReconciler) handleDbUserDelete(ctx context.Context, dbusercr *kindav1beta1.DbUser, dbcr *kindav1beta1.Database) (reconcile.Result, error) {
+	reconcileResult := reconcile.Result{RequeueAfter: r.Interval}
+	finalizer := "dbuser." + dbusercr.Name
+	if !commonhelper.ContainsString(dbusercr.Finalizers, finalizer) {
+		return reconcileResult, nil
+	}
+
+	userSecret, err := r.getDbUserSecret(ctx, dbusercr)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return r.manageError(ctx, dbusercr, err, true)
+	}
+	if k8serrors.IsNotFound(err) {
+		userSecret = nil
+	}
+
+	creds, err := dbUserDeleteCredentials(dbusercr, dbcr, userSecret)
+	if err != nil {
+		return r.manageError(ctx, dbusercr, err, false)
+	}
+
+	instance := &kindav1beta1.DbInstance{}
+	if err := r.Get(ctx, types.NamespacedName{Name: dbcr.Spec.Instance}, instance); err != nil {
+		return r.manageError(ctx, dbusercr, err, false)
+	}
+	db, dbuser, err := dbhelper.FetchDatabaseData(ctx, dbcr, creds, instance)
+	if err != nil {
+		return r.manageError(ctx, dbusercr, err, false)
+	}
+	existingUser := configureDbUser(ctx, dbusercr, dbuser, creds)
+
+	adminSecretResource, err := r.getAdminSecret(ctx, dbcr)
+	if err != nil {
+		return r.manageError(ctx, dbusercr, err, false)
+	}
+	adminCred, err := db.ParseAdminCredentials(ctx, adminSecretResource.Data)
+	if err != nil {
+		return r.manageError(ctx, dbusercr, err, false)
+	}
+
+	if userSecret != nil {
+		if err := r.handleTemplatedCredentials(ctx, dbcr, dbusercr, dbuser); err != nil && !k8serrors.IsNotFound(err) {
+			return r.manageError(ctx, dbusercr, err, true)
+		}
+	}
+	if existingUser {
+		if err := database.RevokePermissions(ctx, db, dbuser, adminCred); err != nil {
+			return r.manageError(ctx, dbusercr, err, false)
+		}
+	} else if err := database.DeleteUser(ctx, db, dbuser, adminCred); err != nil {
+		return r.manageError(ctx, dbusercr, err, false)
+	}
+
+	if userSecret != nil {
+		if err := r.kubeHelper.HandleDelete(ctx, userSecret); err != nil && !k8serrors.IsNotFound(err) {
+			return r.manageError(ctx, dbusercr, err, false)
+		}
+	}
+
+	kci.RemoveFinalizer(&dbcr.ObjectMeta, finalizer)
+	if err := r.Update(ctx, dbcr); err != nil {
+		return r.manageError(ctx, dbusercr, err, false)
+	}
+	kci.RemoveFinalizer(&dbusercr.ObjectMeta, finalizer)
+	if err := r.Update(ctx, dbusercr); err != nil {
+		return r.manageError(ctx, dbusercr, err, false)
+	}
+
+	return reconcileResult, nil
+}
+
+func dbUserDeleteCredentials(dbusercr *kindav1beta1.DbUser, dbcr *kindav1beta1.Database, userSecret *corev1.Secret) (database.Credentials, error) {
+	creds := database.Credentials{
+		Name:     dbcr.Status.DatabaseName,
+		Username: dbusercr.Status.UserName,
+	}
+	if userSecret != nil && (creds.Name == "" || creds.Username == "") {
+		secretCreds, err := parseDbUserSecretData(dbcr.Status.Engine, userSecret.Data)
+		if err != nil {
+			return creds, err
+		}
+		if creds.Name == "" {
+			creds.Name = secretCreds.Name
+		}
+		if creds.Username == "" {
+			creds.Username = secretCreds.Username
+		}
+	}
+	if creds.Username == "" {
+		username, err := dbhelper.GenerateDatabaseUsername(dbusercr.ObjectMeta, dbcr.Status.Engine, dbusercr.Spec.ExistingUser)
+		if err != nil {
+			return creds, err
+		}
+		creds.Username = username
+	}
+	if creds.Name == "" {
+		return creds, errors.New("database name is not recorded in status")
+	}
+
+	return creds, nil
+}
+
+func configureDbUser(ctx context.Context, dbusercr *kindav1beta1.DbUser, dbuser *database.DatabaseUser, creds database.Credentials) bool {
+	log := log.FromContext(ctx)
+	if val, ok := dbusercr.Annotations[consts.GRANT_TO_ADMIN_ON_DELETE]; ok {
+		boolVal, err := strconv.ParseBool(val)
+		if err != nil {
+			log.Info("can't parse a value of an annotation into a bool, ignoring", "annotation", consts.GRANT_TO_ADMIN_ON_DELETE, "value", val, "error", err)
+		} else {
+			dbuser.GrantToAdminOnDelete = boolVal
+		}
+	}
+
+	dbuser.ExtraPrivileges = dbusercr.Spec.ExtraPrivileges
+	dbuser.GrantToAdmin = dbusercr.Spec.GrantToAdmin
+	dbuser.AccessType = dbusercr.Spec.AccessType
+	dbuser.Password = creds.Password
+	dbuser.Username = creds.Username
+
+	existingUser := false
+	// TODO: Remove this annotation
+	if allowExistingRaw, ok := dbusercr.Annotations[consts.ALLOW_EXISTING_USER]; ok {
+		log.Info("Annotation is deprecated, please use .spec.existingUser instead", "annotation", consts.ALLOW_EXISTING_USER)
+		boolVal, err := strconv.ParseBool(allowExistingRaw)
+		if err != nil {
+			log.Info("can't parse a value of an annotation into a bool, ignoring", "annotation", consts.ALLOW_EXISTING_USER, "value", allowExistingRaw, "error", err)
+		} else {
+			existingUser = boolVal
+		}
+	}
+	if len(dbusercr.Spec.ExistingUser) > 0 {
+		existingUser = true
+	}
+
+	return existingUser
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/dbuser_controller_test.go
+++ b/internal/controller/dbuser_controller_test.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 DB-Operator Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controller
+
+import (
+	"testing"
+
+	kindav1beta1 "github.com/db-operator/db-operator/v2/api/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestUnitDbUserDeleteCredentials(t *testing.T) {
+	dbcr := &kindav1beta1.Database{
+		Status: kindav1beta1.DatabaseStatus{
+			DatabaseName: "test-database",
+			Engine:       "postgres",
+		},
+	}
+
+	t.Run("uses the username recorded in status", func(t *testing.T) {
+		dbusercr := &kindav1beta1.DbUser{
+			Status: kindav1beta1.DbUserStatus{UserName: "status-user"},
+		}
+
+		creds, err := dbUserDeleteCredentials(dbusercr, dbcr, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "test-database", creds.Name)
+		assert.Equal(t, "status-user", creds.Username)
+	})
+
+	t.Run("uses the Secret for a legacy DbUser", func(t *testing.T) {
+		dbusercr := &kindav1beta1.DbUser{}
+		secret := &corev1.Secret{Data: map[string][]byte{
+			"POSTGRES_DB":       []byte("secret-database"),
+			"POSTGRES_USER":     []byte("secret-user"),
+			"POSTGRES_PASSWORD": []byte("password"),
+		}}
+
+		creds, err := dbUserDeleteCredentials(dbusercr, dbcr, secret)
+		require.NoError(t, err)
+		assert.Equal(t, "test-database", creds.Name)
+		assert.Equal(t, "secret-user", creds.Username)
+	})
+
+	t.Run("derives the username when the legacy Secret is missing", func(t *testing.T) {
+		dbusercr := &kindav1beta1.DbUser{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "reader"},
+		}
+
+		creds, err := dbUserDeleteCredentials(dbusercr, dbcr, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "test-reader", creds.Username)
+	})
+
+	t.Run("uses an existing username when the legacy Secret is missing", func(t *testing.T) {
+		dbusercr := &kindav1beta1.DbUser{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "reader"},
+			Spec:       kindav1beta1.DbUserSpec{ExistingUser: "existing-reader"},
+		}
+
+		creds, err := dbUserDeleteCredentials(dbusercr, dbcr, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "existing-reader", creds.Username)
+	})
+}

--- a/internal/helpers/database/database.go
+++ b/internal/helpers/database/database.go
@@ -175,24 +175,22 @@ func GenerateDatabaseSecretData(objectMeta metav1.ObjectMeta, engine, dbName, ex
 	const (
 		// https://dev.mysql.com/doc/refman/5.7/en/identifier-length.html
 		mysqlDBNameLengthLimit = 63
-		// https://dev.mysql.com/doc/refman/5.7/en/replication-features-user-names.html
-		mysqlUserLengthLimit = 32
 	)
 	if len(dbName) == 0 {
 		dbName = objectMeta.Namespace + "-" + objectMeta.Name
 	}
-	var dbUser string
+	dbUser, err := GenerateDatabaseUsername(objectMeta, engine, existingUser)
+	if err != nil {
+		return nil, err
+	}
 	var dbPassword string
 	if len(existingUser) > 0 {
-		dbUser = existingUser
 		dbPassword = ""
 	} else {
-		var err error
 		dbPassword, err = kci.GeneratePass()
 		if err != nil {
 			return nil, err
 		}
-		dbUser = objectMeta.Namespace + "-" + objectMeta.Name
 	}
 	switch engine {
 	case "postgres":
@@ -205,12 +203,30 @@ func GenerateDatabaseSecretData(objectMeta metav1.ObjectMeta, engine, dbName, ex
 	case "mysql":
 		data := map[string][]byte{
 			consts.MYSQL_DB:       []byte(kci.StringSanitize(dbName, mysqlDBNameLengthLimit)),
-			consts.MYSQL_USER:     []byte(kci.StringSanitize(dbUser, mysqlUserLengthLimit)),
+			consts.MYSQL_USER:     []byte(dbUser),
 			consts.MYSQL_PASSWORD: []byte(dbPassword),
 		}
 		return data, nil
 	default:
 		return nil, errors.New("not supported engine type")
+	}
+}
+
+// GenerateDatabaseUsername returns the external username stored in generated credentials.
+func GenerateDatabaseUsername(objectMeta metav1.ObjectMeta, engine, existingUser string) (string, error) {
+	username := existingUser
+	if len(username) == 0 {
+		username = objectMeta.Namespace + "-" + objectMeta.Name
+	}
+
+	switch engine {
+	case "postgres":
+		return username, nil
+	case "mysql":
+		// https://dev.mysql.com/doc/refman/5.7/en/replication-features-user-names.html
+		return kci.StringSanitize(username, 32), nil
+	default:
+		return "", fmt.Errorf("unknown database engine: %s", engine)
 	}
 }
 

--- a/internal/helpers/database/database_test.go
+++ b/internal/helpers/database/database_test.go
@@ -26,9 +26,11 @@ import (
 	"github.com/db-operator/db-operator/v2/internal/utils/testutils"
 	"github.com/db-operator/db-operator/v2/pkg/consts"
 	"github.com/db-operator/db-operator/v2/pkg/utils/database"
+	"github.com/db-operator/db-operator/v2/pkg/utils/kci"
 	"github.com/db-operator/db-operator/v2/pkg/utils/templates"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -42,6 +44,19 @@ func TestUnitDeterminPostgresType(t *testing.T) {
 	db, _, _ := dbhelper.FetchDatabaseData(ctx, postgresDbCr, testDbcred, &instance)
 	_, ok := db.(database.Postgres)
 	assert.Equal(t, ok, true, "expected true")
+}
+
+func TestUnitGenerateDatabaseUsername(t *testing.T) {
+	objectMeta := metav1.ObjectMeta{Namespace: "Test-Namespace", Name: "Reader"}
+
+	username, err := dbhelper.GenerateDatabaseUsername(objectMeta, "postgres", "")
+	assert.NoError(t, err)
+	assert.Equal(t, "Test-Namespace-Reader", username)
+
+	existingUser := "Existing_User_With_A_Name_Longer_Than_Thirty_Two_Characters"
+	username, err = dbhelper.GenerateDatabaseUsername(objectMeta, "mysql", existingUser)
+	assert.NoError(t, err)
+	assert.Equal(t, kci.StringSanitize(existingUser, 32), username)
 }
 
 func TestUnitDeterminMysqlType(t *testing.T) {


### PR DESCRIPTION
## Summary

- Finalize DbUsers without requiring their generated credential Secret.
- Record the external username in status and derive it for older resources when needed.
- Use the same username generation for creation and deletion.

Closes https://github.com/db-operator/db-operator/issues/452

## Testing

- Unit tests, envtest, `go vet`, and golangci-lint
- PostgreSQL integration suite
- kind comparison: the baseline operator remained stuck after the Secret was deleted first; this branch removed the DbUser, Database, external role, and external database
- kind validation of both an upgraded legacy DbUser and a newly created DbUser
